### PR TITLE
fix: fallback to credential file when keychain data is unusable

### DIFF
--- a/packages/cli/src/quota.ts
+++ b/packages/cli/src/quota.ts
@@ -125,7 +125,11 @@ function readClaudeCredentials(): ClaudeCredResult {
   // Try macOS Keychain first
   const keychainJson = readFromKeychain('Claude Code-credentials')
   if (keychainJson) {
-    return parseClaudeCredJson(keychainJson)
+    const keychainResult = parseClaudeCredJson(keychainJson)
+    if (keychainResult.status === 'valid' || keychainResult.status === 'expired') {
+      return keychainResult
+    }
+    // Keychain data unusable (parse_error / not_found) — fall through to file
   }
 
   // Fall back to ~/.claude/.credentials.json
@@ -191,7 +195,11 @@ function readCodexCredentials(): CodexCredResult {
   // Try macOS Keychain first
   const keychainJson = readFromKeychain('Codex Auth')
   if (keychainJson) {
-    return parseCodexCredJson(keychainJson)
+    const keychainResult = parseCodexCredJson(keychainJson)
+    if (keychainResult.status === 'valid' || keychainResult.status === 'expired') {
+      return keychainResult
+    }
+    // Keychain data unusable (parse_error / not_found) — fall through to file
   }
 
   // Fall back to ~/.codex/auth.json


### PR DESCRIPTION
## Summary
- Keychain 中存在不可用的凭据条目时（如格式错误、auth_mode 不匹配），现在会 fallback 到文件读取，而不是直接返回错误
- 同时修复了 `readClaudeCredentials()` 和 `readCodexCredentials()` 两个函数

## Test plan
- [x] macOS 上 Keychain 有有效条目时，优先使用 Keychain 凭据
- [x] macOS 上 Keychain 条目不可用时，fallback 到 `~/.codex/auth.json` / `~/.claude/.credentials.json`
- [x] 无 Keychain 条目时，正常读取文件凭据
- [x] Linux/Windows 上行为不变（不走 Keychain）

Closes #10