### PR TITLE
fix: extract per-file session ID for pi and recognize its cache token fields

### DIFF
--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -89,6 +89,12 @@ function extractSessionId(filePath: string, tool: Tool): string {
     const parts = filePath.split('/')
     return (parts.pop() ?? '').replace('.jsonl', '')
   }
+  if (tool === 'pi') {
+    // Extract UUID from filename like 2026-06-08T14-04-37-182Z_019ea78c-b5be-711c-8f30-c8fc56c92b85.jsonl
+    const filename = filePath.split('/').pop() ?? ''
+    const match = filename.match(/_([^_]+)\.jsonl$/)
+    return match ? match[1] : filename.replace('.jsonl', '')
+  }
   return 'unknown'
 }
 

--- a/packages/core/src/parsers/generic-jsonl.ts
+++ b/packages/core/src/parsers/generic-jsonl.ts
@@ -62,6 +62,7 @@ function usageFromAny(parsed: any): {
     ?? usage.cache_read_tokens
     ?? usage.input_cache_read
     ?? usage.cacheReads
+    ?? usage.cacheRead
     ?? cachedFromDetails,
   )
 
@@ -74,7 +75,8 @@ function usageFromAny(parsed: any): {
       ?? usage.cache_write_input_tokens
       ?? usage.cache_write_tokens
       ?? usage.input_cache_creation
-      ?? usage.cacheWrites,
+      ?? usage.cacheWrites
+      ?? usage.cacheWrite,
     ),
     thinkingTokens: num(
       usage.thinking_tokens


### PR DESCRIPTION
## Summary

Fix two issues with pi agent log parsing:

1. **All pi sessions collapsed into one** — `extractSessionId()` had no branch for pi, so every file got `sessionId = 'unknown'`, merging all sessions into a single row. Now extracts the UUID from the filename (e.g. `2026-06-08T14-04-37-182Z_019ea78c-b5be-711c-8f30-c8fc56c92b85.jsonl` → `019ea78c-b5be-711c-8f30-c8fc56c92b85`).

2. **Cache tokens always zero** — Pi logs use camelCase `cacheRead` / `cacheWrite` in the usage object, but `usageFromAny()` only checked `cacheReads` (with 's') and the snake_case variants. Added the singular camelCase forms to the existing `??` chains.

### Changes

- `packages/cli/src/commands/parse.ts` — add `if (tool === 'pi')` branch in `extractSessionId()`, following the same `filePath.split('/').pop()` + regex pattern as codex/openclaw
- `packages/core/src/parsers/generic-jsonl.ts` — add `usage.cacheRead` and `usage.cacheWrite` to the nullish coalescing chains

### Before / After

| | Before | After |
|---|---|---|
| Sessions shown | 1 (`unknown`) | 165 (individual UUIDs) |
| Cache tokens | Always 0 | Correctly parsed |

## Test plan

- [x] `pnpm --filter @aiusage/core test` — 94 tests passed
- [x] `pnpm --filter @aiusage/web test` — 18 tests passed
- [x] Verified on Windows 11 with 165 pi log files across 5 project directories
- [x] After `clean --all` + restart, dashboard shows all sessions individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)