### PR TITLE
fix: deduplicate Claude Code records by message.id

### DIFF
--- a/packages/core/src/parsers/claude-code.ts
+++ b/packages/core/src/parsers/claude-code.ts
@@ -44,8 +44,11 @@ export class ClaudeCodeParser implements Parser {
     const costSource = model === 'unknown' ? 'unknown' as const : 'pricing' as const
     const provider = inferProvider(model)
 
+    const messageId = parsed.message.id
     const record: StatsRecord = {
-      id: generateRecordId(context.deviceInstanceId, context.sourceFile, context.lineOffset),
+      id: messageId
+        ? generateRecordId(context.deviceInstanceId, messageId, 0)
+        : generateRecordId(context.deviceInstanceId, context.sourceFile, context.lineOffset),
       ts,
       ingestedAt: context.now,
       updatedAt: context.now,


### PR DESCRIPTION
## Summary

Fix Claude Code token/cost overcounting (~2.2x) caused by missing `message.id` deduplication.

### Problem

Claude Code writes multiple JSONL lines per API response sharing the same `message.id` with identical `usage` data:

1. **Intra-file**: one assistant message with multiple content blocks → multiple lines, same message.id
2. **Cross-file**: resume/continue session → history copied to new file, same message.id

The parser generates record IDs from `hash(device + filePath + lineOffset)`, so each duplicate line gets a unique ID and all enter the database.

### Fix

Use `message.id` (when available) instead of `filePath + lineOffset` for record ID generation. Since the DB uses `INSERT OR REPLACE`, same message.id → same record ID → last write wins → natural dedup.

```typescript
const messageId = parsed.message.id
id: messageId
  ? generateRecordId(context.deviceInstanceId, messageId, 0)
  : generateRecordId(context.deviceInstanceId, context.sourceFile, context.lineOffset)
```

Falls back to the existing line-offset-based ID when `message.id` is absent.

### Change

- `packages/core/src/parsers/claude-code.ts` — 1 file, +4/-1 lines

### Verification (real data, ~33K lines across all Claude Code logs)

| Metric | Before | After |
|---|---|---|
| Claude Code records | ~32,724 | 14,674 |
| Unique message.ids in logs | — | 14,619 |
| Overcounting ratio | 2.24x | ~1.00x |

The 55-record difference (14,674 vs 14,619) is from lines without `message.id`, correctly handled by the fallback path.

Cross-verified against [claude-usage](https://github.com/phuryn/claude-usage) which deduplicates by `message.id` and produces matching token counts.

## Test plan

- [x] `pnpm --filter @aiusage/core test` — 94 tests passed
- [x] `pnpm --filter @aiusage/web test` — 26 tests passed
- [x] Full re-parse on real logs: record count matches unique message.id count
- [x] `ON DELETE CASCADE` on tool_calls handles cleanup when `INSERT OR REPLACE` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)