### PR TITLE
fix: use APPDATA instead of LOCALAPPDATA for Qoder DB path on Windows

### DIFF
--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -131,8 +131,8 @@ export function defaultQoderDbPath(): string {
     return join(home, 'Library', 'Application Support', 'Qoder', 'SharedClientCache', 'cache', 'db', 'local.db')
   }
   if (plat === 'win32') {
-    const localAppData = process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local')
-    return join(localAppData, 'Qoder', 'SharedClientCache', 'cache', 'db', 'local.db')
+    const appData = process.env.APPDATA ?? join(home, 'AppData', 'Roaming')
+    return join(appData, 'Qoder', 'SharedClientCache', 'cache', 'db', 'local.db')
   }
   const xdgDataHome = process.env.XDG_DATA_HOME ?? join(home, '.local', 'share')
   return join(xdgDataHome, 'Qoder', 'SharedClientCache', 'cache', 'db', 'local.db')


### PR DESCRIPTION
### Problem
On Windows, `defaultQoderDbPath()` uses `%LOCALAPPDATA%` (`AppData\Local`) to locate the Qoder Desktop SQLite database. However, Qoder Desktop actually stores `local.db` under `%APPDATA%` (`AppData\Roaming`).

This causes `probeQoderDb` to always return `null` on Windows, so Qoder usage data is never imported.

### Fix
Change the Windows path in `defaultQoderDbPath()` from `LOCALAPPDATA` to `APPDATA`, matching the actual Qoder Desktop storage location:
`%APPDATA%\Qoder\SharedClientCache\cache\db\local.db`

### Changes
- `packages/cli/src/discovery.ts`: Use `APPDATA` (Roaming) instead of `LOCALAPPDATA` (Local) in the `win32` branch of `defaultQoderDbPath()`