### PR TITLE
fix: propagate backfilled cwd/source_file across devices (#12)

### DIFF
--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -694,9 +694,10 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
           }
         }
 
-        // Write cwd for all records from this file that don't have it yet
+        // Write cwd for all records from this file that don't have it yet.
+        // Bump updated_at so a cwd added to already-synced records re-propagates.
         if (fileCwd) {
-          db.prepare(`UPDATE records SET cwd = ? WHERE source_file = ? AND cwd = ''`).run(fileCwd, filePath)
+          db.prepare(`UPDATE records SET cwd = ?, updated_at = ? WHERE source_file = ? AND cwd = ''`).run(fileCwd, Date.now(), filePath)
         }
 
         wm.setEntry(tool, filePath, {
@@ -1073,24 +1074,7 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
   backfillHermesSourceFiles(db)
 
   // Backfill cwd for records parsed before this feature was added.
-  // Reads only the first 2 KB of each file — enough to find the cwd field.
-  const staleFiles = db.prepare(
-    `SELECT DISTINCT source_file FROM records WHERE cwd = '' AND source_file NOT LIKE 'synced/%'`
-  ).all() as { source_file: string }[]
-  for (const { source_file } of staleFiles) {
-    try {
-      const fd = openSync(source_file, 'r')
-      const buf = Buffer.alloc(2048)
-      const n = readSync(fd, buf, 0, 2048, 0)
-      closeSync(fd)
-      const firstLine = buf.subarray(0, n).toString('utf8').split('\n')[0]
-      const data = JSON.parse(firstLine)
-      const cwd = extractCwdFromJson(data)
-      if (cwd) {
-        db.prepare(`UPDATE records SET cwd = ? WHERE source_file = ? AND cwd = ''`).run(cwd, source_file)
-      }
-    } catch {}
-  }
+  backfillCwd(db)
 
   // Backfill legacy tool_calls with name='Skill' to extract the specific skill name.
   // Historical rows were stored before the parser learned to read block.input.skill.
@@ -1106,7 +1090,40 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
   return { parsedCount, toolCallCount, errors }
 }
 
-function backfillHermesSourceFiles(db: Database.Database): void {
+/**
+ * Backfill cwd for records parsed before cwd extraction existed.
+ * Reads only the first 2 KB of each source file — enough to find the cwd field.
+ *
+ * Bumps updated_at on every changed record so the enriched cwd propagates to
+ * other devices on the next sync. getUnsyncedRecords selects records where
+ * updated_at > synced_at, and mergeRecords only overwrites a remote record when
+ * the incoming updatedAt is strictly newer — so without this bump, backfilled
+ * cwd never reaches peers and cross-device project stats stay broken (issue #12).
+ */
+export function backfillCwd(db: Database.Database): void {
+  const staleFiles = db.prepare(
+    `SELECT DISTINCT source_file FROM records WHERE cwd = '' AND source_file NOT LIKE 'synced/%'`
+  ).all() as { source_file: string }[]
+  const updateStmt = db.prepare(
+    `UPDATE records SET cwd = ?, updated_at = ? WHERE source_file = ? AND cwd = ''`
+  )
+  for (const { source_file } of staleFiles) {
+    try {
+      const fd = openSync(source_file, 'r')
+      const buf = Buffer.alloc(2048)
+      const n = readSync(fd, buf, 0, 2048, 0)
+      closeSync(fd)
+      const firstLine = buf.subarray(0, n).toString('utf8').split('\n')[0]
+      const data = JSON.parse(firstLine)
+      const cwd = extractCwdFromJson(data)
+      if (cwd) {
+        updateStmt.run(cwd, Date.now(), source_file)
+      }
+    } catch {}
+  }
+}
+
+export function backfillHermesSourceFiles(db: Database.Database): void {
   // Old hermes records used the bare dbPath as source_file.
   // Update them to "dbPath:session:<id>:<title>" for per-session project grouping.
   const rows = db.prepare(`
@@ -1136,13 +1153,15 @@ function backfillHermesSourceFiles(db: Database.Database): void {
     }
   } catch {}
 
-  const updateStmt = db.prepare(`UPDATE records SET source_file = ? WHERE tool = 'hermes' AND session_id = ? AND source_file = ?`)
+  // Bump updated_at so the rewritten source_file propagates cross-device on the
+  // next sync (see backfillCwd for why the bump is required).
+  const updateStmt = db.prepare(`UPDATE records SET source_file = ?, updated_at = ? WHERE tool = 'hermes' AND session_id = ? AND source_file = ?`)
   for (const row of rows) {
     const title = (titleMap.get(row.session_id) || '').replace(/[/\\:]/g, '_').slice(0, 80)
     const newSourceFile = title
       ? `${row.source_file}:session:${row.session_id}:${title}`
       : `${row.source_file}:session:${row.session_id}`
-    updateStmt.run(newSourceFile, row.session_id, row.source_file)
+    updateStmt.run(newSourceFile, Date.now(), row.session_id, row.source_file)
   }
 }
 

--- a/packages/cli/src/db/migrations/index.ts
+++ b/packages/cli/src/db/migrations/index.ts
@@ -10,6 +10,7 @@ import { migrateV8 } from './v8.js'
 import { migrateV9 } from './v9.js'
 import { migrateV10 } from './v10.js'
 import { migrateV11 } from './v11.js'
+import { migrateV12 } from './v12.js'
 import { createSchemaVersionTable } from '../schema.js'
 
 const MIGRATIONS = [
@@ -24,6 +25,7 @@ const MIGRATIONS = [
   { version: 9, migrate: migrateV9 },
   { version: 10, migrate: migrateV10 },
   { version: 11, migrate: migrateV11 },
+  { version: 12, migrate: migrateV12 },
 ]
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/cli/src/db/migrations/v12.ts
+++ b/packages/cli/src/db/migrations/v12.ts
@@ -1,0 +1,30 @@
+import type Database from 'better-sqlite3'
+
+/**
+ * Issue #12 repair migration.
+ *
+ * v1.5.0–v1.5.7 shipped a cwd/source_file backfill that enriched local records
+ * but forgot to bump `updated_at`. Because cross-device propagation only
+ * re-uploads records where `updated_at > synced_at` (and the remote merge only
+ * overwrites when the incoming `updatedAt` is strictly newer), the enriched
+ * cwd/source_file never reached other devices. On the device running
+ * `aiusage serve`, Codex (and other cwd-dependent) projects therefore stayed
+ * invisible because the synced rows carry no cwd and no source_file.
+ *
+ * The backfill itself is fixed to bump `updated_at` going forward, but users who
+ * already ran the buggy version have cwd populated locally (so the corrected
+ * `WHERE cwd = ''` backfill no longer matches them). This one-time migration
+ * re-marks those already-enriched records as changed so the next sync re-uploads
+ * them with the complete wire format. Record ids are device-scoped, so bumping
+ * `updated_at` only re-uploads each device's own rows (last-write-wins is safe).
+ */
+export function migrateV12(db: Database.Database): void {
+  db.prepare(`
+    UPDATE records
+    SET updated_at = ?
+    WHERE source_file NOT LIKE 'synced/%'
+      AND (cwd != '' OR source_file LIKE '%:session:%')
+  `).run(Date.now())
+
+  db.prepare('INSERT INTO schema_version (version) VALUES (12)').run()
+}

--- a/packages/cli/tests/commands/backfill-sync-propagation.test.ts
+++ b/packages/cli/tests/commands/backfill-sync-propagation.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord, getUnsyncedRecords } from '../../src/db/records.js'
+import { backfillCwd, backfillHermesSourceFiles } from '../../src/commands/parse.js'
+import type { StatsRecord } from '@aiusage/core'
+
+// Regression tests for issue #12: backfills that enrich records (cwd, hermes
+// source_file) must bump updated_at so the enriched data propagates to other
+// devices on the next sync. Without the bump, getUnsyncedRecords never re-selects
+// the record (it filters updated_at > synced_at) and the cross-device project
+// stats stay broken — Codex sessions vanish on the device running `aiusage serve`.
+
+const testDir = join(tmpdir(), 'aiusage-backfill-sync-test')
+
+function makeSyncedRecord(overrides: Partial<StatsRecord>): StatsRecord {
+  // updatedAt < syncedAt simulates "already uploaded, untouched since".
+  return {
+    id: 'rec-1',
+    ts: 1000,
+    ingestedAt: 1000,
+    syncedAt: 5000,
+    updatedAt: 1000,
+    lineOffset: 0,
+    tool: 'codex',
+    model: 'gpt-5',
+    provider: 'openai',
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0,
+    costSource: 'pricing',
+    sessionId: 'sess-1',
+    sourceFile: '',
+    cwd: '',
+    device: 'host-b',
+    deviceInstanceId: 'device-b',
+    platform: 'darwin',
+    ...overrides,
+  }
+}
+
+describe('backfill sync propagation (issue #12)', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+    db = new Database(':memory:')
+    initializeDatabase(db)
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('backfillCwd sets cwd AND re-marks the record as unsynced', () => {
+    const codexFile = join(testDir, 'rollout-test.jsonl')
+    writeFileSync(codexFile, JSON.stringify({
+      type: 'session_meta',
+      payload: { id: 'sess-1', cwd: '/Users/alice/Projects/my-project' },
+    }) + '\n')
+
+    insertRecord(db, makeSyncedRecord({ sourceFile: codexFile, cwd: '' }))
+
+    // Already synced → not in the unsynced set before the backfill.
+    expect(getUnsyncedRecords(db).map(r => r.id)).not.toContain('rec-1')
+
+    backfillCwd(db)
+
+    const row = db.prepare('SELECT cwd, updated_at, synced_at FROM records WHERE id = ?').get('rec-1') as {
+      cwd: string; updated_at: number; synced_at: number
+    }
+    expect(row.cwd).toBe('/Users/alice/Projects/my-project')
+    // The bump is what makes it propagate: updated_at must now exceed synced_at.
+    expect(row.updated_at).toBeGreaterThan(row.synced_at)
+    expect(getUnsyncedRecords(db).map(r => r.id)).toContain('rec-1')
+  })
+
+  it('backfillHermesSourceFiles rewrites source_file AND re-marks as unsynced', () => {
+    const dbPath = join(testDir, 'missing-hermes.db') // no file → title lookup skipped
+    insertRecord(db, makeSyncedRecord({
+      tool: 'hermes',
+      sourceFile: dbPath,
+      cwd: 'n/a',
+      sessionId: 'sess-1',
+    }))
+
+    expect(getUnsyncedRecords(db).map(r => r.id)).not.toContain('rec-1')
+
+    backfillHermesSourceFiles(db)
+
+    const row = db.prepare('SELECT source_file, updated_at, synced_at FROM records WHERE id = ?').get('rec-1') as {
+      source_file: string; updated_at: number; synced_at: number
+    }
+    expect(row.source_file).toBe(`${dbPath}:session:sess-1`)
+    expect(row.updated_at).toBeGreaterThan(row.synced_at)
+    expect(getUnsyncedRecords(db).map(r => r.id)).toContain('rec-1')
+  })
+})

--- a/packages/cli/tests/commands/status.test.ts
+++ b/packages/cli/tests/commands/status.test.ts
@@ -21,7 +21,7 @@ describe('Status Command', () => {
     expect(status.deviceName).toBeDefined()
     expect(status.dbPath).toBe(':memory:')
     expect(status.databaseSize).toBeDefined()
-    expect(status.schemaVersion).toBe(11)
+    expect(status.schemaVersion).toBe(12)
     expect(status.tableCount).toBeGreaterThan(0)
     expect(status.viewCount).toBe(3)
     expect(status.recordCount).toBe(0)

--- a/packages/cli/tests/db/migration-v12.test.ts
+++ b/packages/cli/tests/db/migration-v12.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord, getUnsyncedRecords } from '../../src/db/records.js'
+import { migrateV12 } from '../../src/db/migrations/v12.js'
+import type { StatsRecord } from '@aiusage/core'
+
+// Issue #12: users who ran the buggy v1.5.0–v1.5.7 backfill have cwd populated
+// locally but never propagated (updated_at was not bumped). The corrected
+// `WHERE cwd = ''` backfill no longer matches them, so migration v12 must
+// re-mark already-enriched records as changed to force a one-time re-upload.
+
+function makeRecord(overrides: Partial<StatsRecord>): StatsRecord {
+  return {
+    id: 'rec',
+    ts: 1000,
+    ingestedAt: 1000,
+    syncedAt: 5000,
+    updatedAt: 1000, // < syncedAt → looks already-synced-and-untouched
+    lineOffset: 0,
+    tool: 'codex',
+    model: 'gpt-5',
+    provider: 'openai',
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0,
+    costSource: 'pricing',
+    sessionId: 'sess',
+    sourceFile: '/Users/a/.codex/sessions/2026/06/01/rollout-x.jsonl',
+    cwd: '',
+    device: 'host-b',
+    deviceInstanceId: 'device-b',
+    platform: 'darwin',
+    ...overrides,
+  }
+}
+
+describe('migration v12 (issue #12 re-propagation repair)', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    initializeDatabase(db) // builds full schema; ends at v12
+    // initializeDatabase already ran v12 on the empty DB. Roll back just the
+    // version row so we can seed records and re-run migrateV12 deterministically.
+    db.prepare('DELETE FROM schema_version WHERE version = 12').run()
+  })
+
+  afterEach(() => db.close())
+
+  it('bumps updated_at on cwd-enriched records so they re-propagate', () => {
+    insertRecord(db, makeRecord({ id: 'codex-enriched', cwd: '/Users/a/Projects/proj' }))
+
+    expect(getUnsyncedRecords(db).map(r => r.id)).not.toContain('codex-enriched')
+
+    migrateV12(db)
+
+    const row = db.prepare('SELECT updated_at, synced_at FROM records WHERE id = ?').get('codex-enriched') as {
+      updated_at: number; synced_at: number
+    }
+    expect(row.updated_at).toBeGreaterThan(row.synced_at)
+    expect(getUnsyncedRecords(db).map(r => r.id)).toContain('codex-enriched')
+  })
+
+  it('bumps hermes per-session source_file records', () => {
+    insertRecord(db, makeRecord({
+      id: 'hermes-enriched',
+      tool: 'hermes',
+      cwd: '',
+      sourceFile: '/path/to/hermes.db:session:s1:My Title',
+    }))
+
+    migrateV12(db)
+
+    expect(getUnsyncedRecords(db).map(r => r.id)).toContain('hermes-enriched')
+  })
+
+  it('does not touch records without cwd or session source_file', () => {
+    insertRecord(db, makeRecord({ id: 'no-cwd', cwd: '', sourceFile: '/Users/a/.codex/sessions/x.jsonl' }))
+
+    migrateV12(db)
+
+    expect(getUnsyncedRecords(db).map(r => r.id)).not.toContain('no-cwd')
+  })
+
+  it('does not re-propagate merged synced/ records', () => {
+    insertRecord(db, makeRecord({ id: 'merged', cwd: '/Users/a/Projects/proj', sourceFile: 'synced/device-x' }))
+
+    migrateV12(db)
+
+    expect(getUnsyncedRecords(db).map(r => r.id)).not.toContain('merged')
+  })
+})

--- a/packages/cli/tests/db/schema.test.ts
+++ b/packages/cli/tests/db/schema.test.ts
@@ -117,7 +117,7 @@ describe('Database Schema', () => {
   it('records latest schema version', () => {
     initializeDatabase(db)
     const version = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get()
-    expect((version as any).version).toBe(11)
+    expect((version as any).version).toBe(12)
   })
 
   it('queries visualization views successfully', () => {


### PR DESCRIPTION
Closes #12

## 问题

在运行 `aiusage serve` 的设备上，跨设备的项目统计看不到 **Codex**（以及其他依赖 cwd 的）项目：同步过来的记录既没有 `cwd` 也没有 `source_file`，导致 `/api/projects` 把它们整条跳过。

## 根本原因

这**不是路径推断问题**，而是回填的同步传播 bug：

- `cwd` 回填与 `backfillHermesSourceFiles` 更新了记录，但**没有 bump `updated_at`**。
- 跨设备传播只会重新上传 `updated_at > synced_at` 的记录，且远端 `mergeRecords` 只在 `updatedAt` 严格更新时才覆盖 → 被回填的字段**永远传不到其他设备**。
- 读取侧 `/api/projects` 用 `if (!row.source_file) continue` 丢弃空 source_file 行；codex 的源路径里没有项目信息，于是项目从列表中消失。

`backfillCodexModels` 本就正确 bump 了 `updated_at`，它是正确参照——另外两个回填是漏写 bump 的兄弟 bug。

bug 版自 **v1.5.0** 起已发布。已升级用户本地 `cwd` 早已填上，所以修正后的 `WHERE cwd = ''` 回填已无法匹配它们 —— 修复存量数据必须配合一次性迁移，而非可选项。

## 改动

1. **回填时 bump `updated_at`**：抽取 `backfillCwd`（对齐 `backfillCodexModels`），并在 per-file cwd 写入与 `backfillHermesSourceFiles` 中一并 bump。
2. **迁移 v12**：修复已运行过 bug 版的用户——把已 enriched（有 cwd 或 hermes `:session:` source_file）的本地记录重新标记为已变更，强制下次同步重传一次完整 wire 格式。记录 id 按设备归属，bump `updated_at` 只会重传本设备自己的行（last-write-wins 安全）。
3. 新增针对回填 bump 与 v12 修复的测试。

## 数据流验证（全 5 链路）

| # | 链路 | 状态 |
|---|------|------|
| 1 | v12 bump `updated_at` | ✅ |
| 2 | host B `getUnsyncedRecords` 重新选中 | ✅ |
| 3 | `uploadFile`→`mergeRecords` 覆盖远端 ndjson（bump 后 updatedAt 严格更大） | ✅ 实际断点，bump 修复 |
| 4 | host A `pull`→`insertSyncedRecord` 的 `ON CONFLICT DO UPDATE ... WHERE excluded.updated_at > synced_records.updated_at` 更新旧行 `source_file/cwd` | ✅ |
| 5 | `/api/projects`（特定设备）直接查 `synced_records` → 从 cwd 提取 project | ✅ |

两种故障模式都被覆盖：被 `getUnsyncedRecords` 漏掉（已 synced），以及被选中但 `mergeRecords` 因 updatedAt 相等不覆盖 —— 两者都靠 bump 解决。

## 注意

- **一次性全量重传**：迁移会让已 enriched 的本地记录重传一次（含已正确传播的记录，属冗余但无害——远端只是被同内容 + 更新的 updatedAt 覆盖）。
- **范围**：本 PR 针对 GitHub/S3 ndjson 同步路径。用 HTTP cloud 同步的用户，建议另行确认 site 服务端 upsert 会更新 `source_file/cwd`。
- 「All devices」汇总视图本就只统计本地项目（既有行为，非本 PR 引入），报告者是选特定设备，不受影响。

## Test plan

- [x] `tests/commands/backfill-sync-propagation.test.ts` — 回填后记录被重新标记为待同步
- [x] `tests/db/migration-v12.test.ts` — v12 只 bump enriched 记录，跳过 `synced/` 与无 cwd 记录
- [x] 更新 schema 版本断言 11 → 12（schema/status 测试）
- [x] CLI 395 + core 96 全部通过；无新增类型错误
- [ ] 报告者侧验证：host B 升级 → `parse`/`serve`（跑 v12）→ 同步 → host A 拉取后可见 Codex 项目