### PR TITLE
fix: eliminate full-table scans when parsing large Cursor state.vscdb…

### DIFF
--- a/packages/cli/src/commands/parse-cursor.ts
+++ b/packages/cli/src/commands/parse-cursor.ts
@@ -11,6 +11,7 @@ export interface CursorImportOptions {
   platform?: string
   now: number
   cursor: CursorCursor | null
+  onProgress?: (current: number, total: number, recordsFound: number) => void
 }
 
 export interface CursorImportResult {
@@ -102,15 +103,30 @@ export function runParseCursor(
   db: Database.Database,
   options: CursorImportOptions,
 ): CursorImportResult {
-  const { dbPath, device, deviceInstanceId, platform, now, cursor } = options
+  const { dbPath, device, deviceInstanceId, platform, now, cursor, onProgress } = options
   const records: StatsRecord[] = []
   const toolCalls: ToolCallRecord[] = []
   const errors: string[] = []
   let lastCursor: CursorCursor | null = null
 
-  // Fetch all composerData entries with content
+  // Gracefully skip databases without the expected table (e.g. residual dbs
+  // left behind by old/uninstalled Cursor versions)
+  const hasTable = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cursorDiskKV'`)
+    .get()
+  if (!hasTable) {
+    return { records, toolCalls, nextCursor: lastCursor, errors }
+  }
+
+  // Fetch all composerData entries with content.
+  // Use an index-friendly range scan instead of LIKE: SQLite's LIKE is
+  // case-insensitive by default and cannot use the `key TEXT UNIQUE` index,
+  // so every LIKE prefix query degenerates into a full-table scan, which is
+  // fatal on multi-GB state.vscdb files. Cursor writes keys with exact
+  // lowercase prefixes, so binary range comparison matches the same rows.
+  // (';' is the ASCII character right after ':')
   const composerRows = db
-    .prepare(`SELECT key, CAST(value AS TEXT) as value FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND length(value) > 100`)
+    .prepare(`SELECT key, CAST(value AS TEXT) as value FROM cursorDiskKV WHERE key >= 'composerData:' AND key < 'composerData;' AND length(value) > 100`)
     .all() as ComposerRow[]
 
   // Parse and filter composerData entries
@@ -152,17 +168,25 @@ export function runParseCursor(
     return { records, toolCalls, nextCursor: lastCursor, errors }
   }
 
-  // Prepare statement to fetch all bubbles for a composer
+  // Prepare statement to fetch all bubbles for a composer.
+  // Range bounds instead of LIKE so the key index is used (see above);
+  // otherwise each composer triggers a full-table scan.
   const bubbleStmt = db.prepare(
-    `SELECT CAST(value AS TEXT) as value FROM cursorDiskKV WHERE key LIKE ?`,
+    `SELECT CAST(value AS TEXT) as value FROM cursorDiskKV WHERE key >= ? AND key < ?`,
   )
 
+  let processed = 0
   for (const composer of filtered) {
     lastCursor = { lastCreatedAt: composer.createdAt, lastId: composer.composerId }
+    processed += 1
+    onProgress?.(processed, filtered.length, records.length)
 
     try {
       // Fetch all bubble entries for this conversation
-      const bubbleRows = bubbleStmt.all(`bubbleId:${composer.composerId}:%`) as { value: string }[]
+      const bubbleRows = bubbleStmt.all(
+        `bubbleId:${composer.composerId}:`,
+        `bubbleId:${composer.composerId};`,
+      ) as { value: string }[]
 
       let totalInputTokens = 0
       let totalOutputTokens = 0

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -948,6 +948,7 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
     try {
       const cursorDb = new Database(cursorDbPath, { readonly: true })
       try {
+        let cursorProgressFired = false
         const result = runParseCursor(cursorDb, {
           dbPath: cursorDbPath,
           device,
@@ -955,6 +956,10 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
           platform: devicePlatform,
           now: Date.now(),
           cursor: wm.getCursorCursor(),
+          onProgress: (current, total, recordsFound) => {
+            cursorProgressFired = true
+            onProgress({ phase: 'Parsing SQLite', tool: 'cursor', current, total, records: parsedCount + recordsFound, toolCalls: toolCallCount })
+          },
         })
 
         for (const record of result.records) insertRecord(db, record)
@@ -966,7 +971,9 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
         parsedCount += result.records.length
         toolCallCount += result.toolCalls.length
         errors.push(...result.errors)
-        onProgress({ phase: 'Parsing SQLite', tool: 'cursor', current: 1, total: 1, records: parsedCount, toolCalls: toolCallCount })
+        if (!cursorProgressFired) {
+          onProgress({ phase: 'Parsing SQLite', tool: 'cursor', current: 1, total: 1, records: parsedCount, toolCalls: toolCallCount })
+        }
       } finally {
         cursorDb.close()
       }

--- a/packages/cli/tests/commands/parse-cursor.test.ts
+++ b/packages/cli/tests/commands/parse-cursor.test.ts
@@ -275,6 +275,78 @@ describe('runParseCursor', () => {
     expect(result.nextCursor).toBeNull()
     expect(result.errors).toHaveLength(0)
   })
+
+  it('skips gracefully when cursorDiskKV table is missing', () => {
+    // Residual dbs from old/uninstalled Cursor versions may lack the table;
+    // the parser must degrade gracefully instead of throwing.
+    const emptyDb = new Database(':memory:')
+    try {
+      const result = runParseCursor(emptyDb, BASE_OPTIONS)
+
+      expect(result.records).toHaveLength(0)
+      expect(result.toolCalls).toHaveLength(0)
+      expect(result.nextCursor).toBeNull()
+      expect(result.errors).toHaveLength(0)
+    } finally {
+      emptyDb.close()
+    }
+  })
+
+  it('ignores unrelated key prefixes', () => {
+    // Large dbs contain many other prefixes (agentKv, checkpointId, ...);
+    // none of them may leak into the stats.
+    db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`).run(
+      'agentKv:some-agent-key',
+      JSON.stringify({ type: 2, tokenCount: { inputTokens: 999999, outputTokens: 999999 } }),
+    )
+    db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`).run(
+      'checkpointId:cp-1',
+      JSON.stringify({ type: 2, tokenCount: { inputTokens: 888888, outputTokens: 888888 } }),
+    )
+    insertComposer(db, 'conv-1', 1779400000000, {})
+    insertBubble(db, 'conv-1', 'b-1', 2, 1000, 100)
+
+    const result = runParseCursor(db, BASE_OPTIONS)
+
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].inputTokens).toBe(1000)
+    expect(result.records[0].outputTokens).toBe(100)
+  })
+
+  it('reports progress per processed conversation', () => {
+    insertComposer(db, 'conv-1', 1779400000000, {})
+    insertBubble(db, 'conv-1', 'b-1', 2, 1000, 100)
+    insertComposer(db, 'conv-2', 1779410000000, {})
+    insertBubble(db, 'conv-2', 'b-2', 2, 2000, 200)
+    insertComposer(db, 'conv-3', 1779420000000, {})
+    insertBubble(db, 'conv-3', 'b-3', 2, 3000, 300)
+
+    const calls: [number, number, number][] = []
+    const result = runParseCursor(db, {
+      ...BASE_OPTIONS,
+      onProgress: (current, total, recordsFound) => calls.push([current, total, recordsFound]),
+    })
+
+    expect(result.records).toHaveLength(3)
+    expect(calls.length).toBe(3)
+    expect(calls.map(([current]) => current)).toEqual([1, 2, 3])
+    expect(calls.every(([, total]) => total === 3)).toBe(true)
+  })
+
+  it('does not report progress when there is nothing new to process', () => {
+    insertComposer(db, 'conv-old', 1779400000000, {})
+    insertBubble(db, 'conv-old', 'b-1', 2, 1000, 100)
+
+    const calls: [number, number, number][] = []
+    const result = runParseCursor(db, {
+      ...BASE_OPTIONS,
+      cursor: { lastCreatedAt: 1779400000000, lastId: 'conv-old' },
+      onProgress: (current, total, recordsFound) => calls.push([current, total, recordsFound]),
+    })
+
+    expect(result.records).toHaveLength(0)
+    expect(calls).toHaveLength(0)
+  })
 })
 
 describe('runParse with cursor', () => {


### PR DESCRIPTION
Fixes #46

## Problem

On a large Cursor `state.vscdb`, `aiusage parse` shows the cursor source
progress at 100% and then spins the CPU (9–14%) for 10+ minutes without
exiting; `aiusage serve` hangs the same way during its startup parse,
making the tool unusable.

Diagnostic data from the affected machine (2.75GB db, `cursorDiskKV` =
210,517 rows):

| key prefix      | rows    | size    |
| --------------- | ------- | ------- |
| `bubbleId:`     | 90,260  | 1024 MB |
| `agentKv:`      | 103,131 | 1007 MB |
| `checkpointId:` | 5,293   | 141 MB  |
| `composerData:` | 857     | 78 MB   |

`lsof` showed the process holding a read handle on the db; `sample`
showed the main thread busy in V8 (CPU-bound, not I/O wait or lock
contention); the db itself is healthy (all sqlite3 CLI queries return
instantly, no corruption, no WAL lock).

## Root cause

The parser issues one `WHERE key LIKE 'bubbleId:<composerId>:%'` query
per composer. SQLite's LIKE is case-insensitive by default
(`case_sensitive_like=OFF` in better-sqlite3), so it cannot use the
`key TEXT UNIQUE` auto-index — `EXPLAIN QUERY PLAN` confirms
`SCAN cursorDiskKV` for every such query. With ~850 composers that means
850+ sequential full-table scans of a 2.75GB table.

Two aggravating factors:

- The existing watermark (`CursorCursor`) was applied in JS only *after*
  the full load, so incremental runs re-scanned the whole table too.
- The SQLite stage emitted no progress — just a single `1/1` event after
  the entire parse finished.

## Fix

- Replace LIKE prefix matching with index-friendly range bounds
  (`key >= 'bubbleId:<id>:' AND key < 'bubbleId:<id>;'`, likewise for
  `composerData:`). The query plan becomes
  `SEARCH cursorDiskKV USING INDEX sqlite_autoindex_cursorDiskKV_1`.
  Cursor writes keys with exact lowercase prefixes, so binary range
  comparison matches the same rows as the ASCII case-insensitive LIKE.
- Incremental runs with no new composers now never touch bubble rows —
  the watermark short-circuits before any bubble query.
- Skip databases whose schema has no `cursorDiskKV` table (e.g. residual
  dbs from old/uninstalled versions) instead of throwing.
- Report per-composer progress during the SQLite stage through the
  existing `ProgressReporter`.

No watermark format change, no new dependencies, and the db is still
opened read-only.

## Testing

- New unit tests (real in-memory better-sqlite3 fixtures): missing-table
  degradation, unrelated key-prefix isolation (`agentKv:` etc. never
  leak into stats), per-composer progress callback, and no progress
  events on no-op incremental runs. Full suite: 53 files / 415 tests
  passing.
- Verified against the real 2.75GB `state.vscdb` (read-only):
  - Per-composer token sums diffed against an independent single-pass
    aggregation over all 90,260 `bubbleId:` rows — **0 mismatches**.
  - Cursor token total after parsing: **114,900,780** — identical to
    the pre-fix value, no data loss.

### Before / after (same machine, same db)

| scenario                              | before                   | after |
| ------------------------------------- | ------------------------ | ----- |
| cursor source full parse (2.75GB db)  | 10+ min, never finished  | ~10s  |
| `aiusage parse` (incremental re-run)  | full re-scan, hung       | ~1s   |
| `aiusage serve` startup parse         | hung, dashboard never up | ~3s   |
