### PR TITLE
fix: never re-upload pulled records under the pulling device's sync namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Cross-device sync re-uploaded pulled records** — records pulled from another device kept their real `source_file`, so the `source_file NOT LIKE 'synced/%'` heuristic treated them as local and re-uploaded them under the pulling device's namespace with colliding ids (`line_offset = 0`), double-counting usage on every machine. Provenance is now an explicit `records.origin` column (`local` | `synced`); only local rows stamped with the current device id are uploaded, and only under that device's namespace. Pull ignores lines that do not belong to the namespace they sit in, and echoes of the device's own records. Migration v13 back-fills `origin` deterministically for existing databases. A new `aiusage sync --repair [--apply] [--all-namespaces]` command reports and, on request, removes contamination from the local database and the remote namespaces. See `docs/sync-repair.md`.
+
+---
+
 ## [1.5.13] - 2026-09-01
 
 ### Fixed

--- a/docs/sync-repair.md
+++ b/docs/sync-repair.md
@@ -1,0 +1,138 @@
+# Repairing cross-device sync contamination
+
+Versions up to 1.5.13 could copy records pulled from one device into another
+device's sync namespace. This document explains how to tell legitimate records
+from copies, and how to clean up existing data with `aiusage sync --repair`.
+
+## What went wrong
+
+Every device uploads its records under its own namespace,
+`data/<deviceInstanceId>/YYYY/MM/DD.ndjson`, and pulls every other namespace.
+Pulled records are stored in `synced_records` and then *merged* into `records`
+so local queries can see them.
+
+The merged rows used to be recognised only by a placeholder
+`source_file = 'synced/<device>'`. When the wire format started carrying the
+real `source_file` and `cwd` (needed for cross-device project statistics),
+merged rows looked exactly like locally parsed rows. The pulling device then:
+
+1. selected them as "unsynced local records",
+2. uploaded them under **its own** namespace, and
+3. because merged rows have `line_offset = 0`, gave every record from one
+   source file the **same** sync id `sha256(originDevice, sourceFile, 0)`.
+
+Each such upload is an *echo*: a collapsed copy of another device's usage,
+carrying the original `deviceInstanceId` but living in the wrong directory.
+Echoes were pulled back by the origin device, merged, and re-uploaded again,
+so a record could exist in several namespaces under several ids and be counted
+more than once on every machine.
+
+## What the fix does
+
+* `records` gained an explicit `origin` column (`local` or `synced`). Only
+  `origin = 'local'` rows stamped with the current device id (or the pre-init
+  `unknown` sentinel) are ever uploaded, and only under that device's
+  namespace. `source_file` is no longer used to decide provenance anywhere.
+* Pull ignores any line whose `deviceInstanceId` is a concrete id different
+  from the namespace it was read from, and any line carrying the pulling
+  device's own id. Such lines can only be echoes; their authoritative copy is
+  in the origin device's namespace.
+* Merged rows keep their wire id and keep `source_file` and `cwd`.
+* Migration v13 back-fills `origin` for existing databases (see below).
+* The cloud backend applies the same rules (own-device records returned by the
+  server are skipped, pulled rows are never pushed).
+
+## Telling legitimate records from copies
+
+Every rule is deterministic; none of them looks at `source_file`.
+
+| Where | Rule | Why it is safe |
+| --- | --- | --- |
+| Local `records` | A row whose `session_id` equals the `session_key` of the `synced_records` row with the same id was written by the merge step. | The merge step is the only writer that stores the 24-hex session-key hash in `session_id`. A parser stores the tool's real session id, which cannot equal `sha256(device + sessionId)[0:24]` of another session (hash pre-image). |
+| Local `records` | A `local` row stamped with a *different, concrete* device id was not parsed here. | Parsers always stamp the current device id, or `unknown` before `aiusage init`. |
+| Remote namespace | A line whose `deviceInstanceId` is a concrete id different from the namespace owner. | Only the owning device writes to its namespace, and after the fix it writes only its own records. |
+| Remote or local | A line/row E is an *echo* when a session key K known anywhere in the system (any namespace, any local row) exists such that `sha256(E.device + "\0" + K)[0:24] === E.sessionKey`. | Re-uploading a merged row hashes its already-hashed session key. A genuine session key is the hash of a tool-generated session id, never of another session's 24-hex key. Usage fields are not compared because backfills may rewrite model, cost or timestamps on the origin device after the echo was taken. |
+| Local `synced_records` | A row stamped with this device's own id. | Pull never reads our own namespace, so our id can only appear there by bouncing through another device. The authoritative row is in `records`. |
+
+Lines with `deviceInstanceId = 'unknown'` are records parsed before
+`aiusage init` created `state.json`. They are legitimate for the namespace they
+sit in and are only removed when the echo rule matches.
+
+Removing an echo never loses usage: by construction the parent it was derived
+from still exists (the origin device's own row or its own namespace line).
+
+## Automatic migration (v13)
+
+The migration runs on first start after upgrading and:
+
+* adds `records.origin` (default `local`),
+* flags rows matching the legacy `synced/` placeholder or the merge
+  fingerprint as `synced`,
+* removes `sync_record_state` bookkeeping for those rows.
+
+It never deletes records. After it runs, contaminated rows stop being counted
+as local usage and stop being uploaded; they remain visible through
+`synced_records`.
+
+## Opt-in cleanup: `aiusage sync --repair`
+
+Nothing is deleted automatically. The repair command reports first:
+
+```
+aiusage sync --repair                    # dry run: this device's namespace + local DB
+aiusage sync --repair --all-namespaces   # dry run, also inspect other devices' namespaces
+```
+
+The report lists, per namespace, how many lines are foreign-device lines and
+how many are echoes, plus the local rows that would be re-flagged or removed.
+Apply it with:
+
+```
+aiusage sync --repair --apply
+aiusage sync --repair --apply --all-namespaces
+```
+
+`--apply` performs, in this order:
+
+1. re-flags local rows that are provably pulled copies as `origin = 'synced'`,
+2. deletes echo rows from `synced_records` and their merged copies in
+   `records` (the originals remain),
+3. removes stale `sync_record_state` rows,
+4. rewrites the contaminated remote files without the foreign/echo lines
+   (deleting a file only if nothing legitimate is left), then commits and
+   pushes (GitHub) or uploads (S3).
+
+Recommended order for a fleet of devices:
+
+1. Upgrade every device. From the first sync onwards the bug cannot recur, and
+   echoes still present remotely are ignored on pull (reported as
+   `ignored: N foreign`).
+2. On one device run `aiusage sync --repair --all-namespaces`, review the
+   report, then re-run with `--apply`.
+3. On every other device run `aiusage sync --repair --apply` (local database
+   only needs cleaning there; its namespace was already rewritten in step 2).
+4. Run `aiusage sync` everywhere. Totals should now agree on all machines.
+
+The cloud backend has no per-device namespaces; `--repair` there cleans only
+the local database.
+
+## Manual procedure (if you prefer not to use the command)
+
+For each file under `data/<owner>/`:
+
+1. Drop every line whose `deviceInstanceId` is neither `<owner>` nor `unknown`.
+2. Collect `sessionKey` of every line in **all** namespaces (before dropping
+   anything, so chains of echoes resolve).
+3. Drop every line whose `sessionKey` equals
+   `sha256(line.device + "\0" + K)` truncated to 24 hex characters for some
+   collected key `K`.
+
+Locally, after upgrading (migration v13 has run):
+
+```sql
+DELETE FROM synced_records WHERE device_instance_id = '<this device id>';
+DELETE FROM records WHERE origin = 'synced' AND id NOT IN (SELECT id FROM synced_records);
+DELETE FROM sync_record_state WHERE record_id IN (SELECT id FROM records WHERE origin = 'synced');
+```
+
+then run `aiusage sync`.

--- a/packages/cli/src/api/server.ts
+++ b/packages/cli/src/api/server.ts
@@ -28,7 +28,7 @@ import { clearCredentials, hasCredentials, loadCredentials, saveCredentials } fr
 import { base64url, sha256Buffer } from '../leaderboard/crypto.js'
 import { uploadLeaderboardData } from '../commands/leaderboard-upload.js'
 import { runParseKelivo } from '../commands/parse-kelivo.js'
-import { insertRecord } from '../db/records.js'
+import { insertRecord, LOCAL_RECORDS_WHERE } from '../db/records.js'
 import { AsyncTaskQueue, type AsyncTaskQueueStatus } from '../db/write-queue.js'
 import { getPricingRegistrySummary, getUserAliasBindings, hasUserPrice, listLocalModelBindings, listPricingAliasTargets, listPricingModels, loadPricingRuntime, removeUserPricingAlias, resetUserPriceToSynced, resolvePriceFromRegistry, setUserPrice, setUserPricingAlias, syncPricingFromLitellm } from '../pricing-registry.js'
 import type { DetectedTool } from '../discovery.js'
@@ -393,7 +393,8 @@ function getToolTypeFilter(toolType: string | null): string {
   return ''
 }
 
-const LOCAL_ONLY_FILTER = "AND source_file NOT LIKE 'synced/%'"
+// Rows merged from synced_records carry origin = 'synced' (see db/records.ts LOCAL_RECORDS_WHERE).
+const LOCAL_ONLY_FILTER = `AND ${LOCAL_RECORDS_WHERE}`
 
 function getDeviceFilter(
   device: string | null | undefined,
@@ -1656,7 +1657,7 @@ export function createApiServer(db: Database.Database, options?: ApiServerOption
         const localRows = db.prepare(`
           SELECT device, device_instance_id AS deviceInstanceId, COUNT(*) AS recordCount
           FROM records
-          WHERE device_instance_id = @currentId AND source_file NOT LIKE 'synced/%'
+          WHERE device_instance_id = @currentId AND ${LOCAL_RECORDS_WHERE}
           GROUP BY device_instance_id
         `).all({ currentId }) as any[]
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { serve } from './commands/serve.js'
 import { runInit } from './commands/init.js'
-import { runSync } from './commands/sync.js'
+import { runSync, runSyncRepair, formatRepairReport } from './commands/sync.js'
 import { generateSummary } from './commands/summary.js'
 import { generateStatus } from './commands/status.js'
 import { exportData } from './commands/export.js'
@@ -359,8 +359,26 @@ program
 program
   .command('sync')
   .description('Sync data with cloud storage')
-  .action(async () => {
+  .option('--repair', 'Report records that an older version copied into the wrong device namespace (dry run unless --apply)')
+  .option('--apply', 'With --repair: perform the cleanup (rewrites this device\'s remote namespace and prunes local echoes)')
+  .option('--all-namespaces', 'With --repair: also clean namespaces owned by other devices')
+  .action(async (opts: { repair?: boolean; apply?: boolean; allNamespaces?: boolean }) => {
     const db = createDatabase(DB_PATH)
+    if (opts.repair) {
+      try {
+        const result = await runSyncRepair(db, { apply: opts.apply, allNamespaces: opts.allNamespaces })
+        if (result.status !== 'ok' || !result.report) {
+          console.error(`✗ ${result.error ?? 'Repair failed'}`)
+          process.exit(1)
+        }
+        console.log(formatRepairReport(result.report))
+      } catch (e) {
+        console.error(`✗ Repair failed: ${e instanceof Error ? e.message : e}`)
+        process.exit(1)
+      }
+      db.close()
+      return
+    }
     const reporter = new SyncProgressReporter()
     reporter.start()
     try {
@@ -369,7 +387,11 @@ program
       })
       reporter.done()
       if (result.status === 'ok') {
-        console.log(`✓ Sync complete — pulled: ${result.pulledCount}, merged: ${result.mergedCount}, uploaded: ${result.uploadedCount}`)
+        const ignored = 'ignoredCount' in result && result.ignoredCount ? `, ignored: ${result.ignoredCount} foreign` : ''
+        console.log(`✓ Sync complete — pulled: ${result.pulledCount}, merged: ${result.mergedCount}, uploaded: ${result.uploadedCount}${ignored}`)
+        if (ignored) {
+          console.log('  Some remote lines belong to a different device than the namespace they are in. Run "aiusage sync --repair" for details.')
+        }
       } else if (result.status === 'blocked_pending_consent') {
         console.error(`✗ ${result.error}`)
         process.exit(1)

--- a/packages/cli/src/commands/leaderboard-upload.ts
+++ b/packages/cli/src/commands/leaderboard-upload.ts
@@ -1,3 +1,4 @@
+import { LOCAL_RECORDS_WHERE } from '../db/records.js'
 import { createDatabase } from '../db/index.js'
 import { getState } from '../init.js'
 import { AIUSAGE_DIR } from '../config.js'
@@ -148,7 +149,7 @@ function getPeriodUsageGroups(
   endTs: number
 ): UsageGroup[] {
   const timeWhere = 'AND ts >= @startTs AND ts <= @endTs'
-  const localOnlyFilter = "AND source_file NOT LIKE 'synced/%'"
+  const localOnlyFilter = `AND ${LOCAL_RECORDS_WHERE}`
   const params = { currentId: currentDeviceInstanceId ?? '', startTs, endTs }
 
   if (currentDeviceInstanceId) {

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -4,7 +4,7 @@ import { basename, join, dirname } from 'node:path'
 import { hostname } from 'node:os'
 import { Aggregator, resolveExchangeRate, generateToolCallId, inferProvider, calculateCost, resolvePrice, generateRecordId, normalizeCodeFuseModel, parseTimestamp, type StatsRecord, type Tool } from '@aiusage/core'
 import type { ToolCallRecord } from '@aiusage/core'
-import { insertRecord } from '../db/records.js'
+import { insertRecord, LOCAL_RECORDS_WHERE } from '../db/records.js'
 import { insertToolCall } from '../db/tool-calls.js'
 import { getState } from '../init.js'
 import { loadConfig, AIUSAGE_DIR } from '../config.js'
@@ -1219,14 +1219,14 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
   // If the current device UUID is known, backfill any records with 'unknown' device_instance_id.
   if (deviceInstanceId !== 'unknown') {
     db.prepare(
-      `UPDATE records SET device_instance_id = ?, device = ? WHERE device_instance_id = 'unknown'`
+      `UPDATE records SET device_instance_id = ?, device = ? WHERE device_instance_id = 'unknown' AND ${LOCAL_RECORDS_WHERE}`
     ).run(deviceInstanceId, device)
   }
 
   // Backfill platform for existing records that have an empty platform field.
   if (devicePlatform) {
     db.prepare(
-      `UPDATE records SET platform = ? WHERE platform = '' AND source_file NOT LIKE 'synced/%'`
+      `UPDATE records SET platform = ? WHERE platform = '' AND ${LOCAL_RECORDS_WHERE}`
     ).run(devicePlatform)
   }
 
@@ -1263,7 +1263,7 @@ export async function runParse(db: Database.Database, filterTool?: string, optio
  */
 export function backfillCwd(db: Database.Database): void {
   const staleFiles = db.prepare(
-    `SELECT DISTINCT source_file FROM records WHERE cwd = '' AND source_file NOT LIKE 'synced/%'`
+    `SELECT DISTINCT source_file FROM records WHERE cwd = '' AND ${LOCAL_RECORDS_WHERE}`
   ).all() as { source_file: string }[]
   const updateStmt = db.prepare(
     `UPDATE records SET cwd = ?, updated_at = ? WHERE source_file = ? AND cwd = ''`
@@ -1292,7 +1292,7 @@ export function backfillHermesSourceFiles(db: Database.Database): void {
     FROM records r
     WHERE r.tool = 'hermes'
       AND r.source_file NOT LIKE '%:session:%'
-      AND r.source_file NOT LIKE 'synced/%'
+      AND r.${LOCAL_RECORDS_WHERE}
   `).all() as { source_file: string; session_id: string }[]
 
   if (rows.length === 0) return
@@ -1333,7 +1333,7 @@ function backfillSkillNames(db: Database.Database): void {
     FROM tool_calls tc
     JOIN records r ON r.id = tc.record_id
     WHERE (tc.name = 'Skill' OR tc.name = 'skill__unknown')
-      AND r.source_file NOT LIKE 'synced/%'
+      AND r.${LOCAL_RECORDS_WHERE}
   `).all() as { id: string; record_id: string; ts: number; call_index: number; source_file: string; line_offset: number }[]
 
   if (rows.length === 0) return
@@ -1382,7 +1382,7 @@ function backfillCodexModels(db: Database.Database): void {
     SELECT id, source_file, line_offset
     FROM records
     WHERE tool = 'codex' AND model = 'unknown'
-      AND source_file NOT LIKE 'synced/%'
+      AND ${LOCAL_RECORDS_WHERE}
   `).all() as { id: string; source_file: string; line_offset: number }[]
 
   if (rows.length === 0) return
@@ -1444,7 +1444,7 @@ function backfillMissingToolCalls(db: Database.Database, exchangeRate?: number):
     FROM records r
     LEFT JOIN tool_calls tc ON tc.record_id = r.id
     WHERE r.tool IN ('codex', 'openclaw', 'qoder')
-      AND r.source_file NOT LIKE 'synced/%'
+      AND r.${LOCAL_RECORDS_WHERE}
       AND tc.id IS NULL
   `).all() as { id: string; source_file: string; tool: Tool; line_offset: number; session_id: string }[]
 

--- a/packages/cli/src/commands/summary.ts
+++ b/packages/cli/src/commands/summary.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3'
 import { getToolCallStats } from '../db/tool-calls.js'
+import { LOCAL_RECORDS_WHERE } from '../db/records.js'
 
 export interface SummaryOptions {
   device?: string
@@ -28,7 +29,8 @@ export function generateSummary(db: Database.Database, options?: SummaryOptions)
   let byToolSql: string
   let byToolParams: Record<string, unknown> = {}
 
-  const localOnlyFilter = "AND source_file NOT LIKE 'synced/%'"
+  // Rows merged from synced_records carry origin = 'synced'; they are counted via synced_records instead.
+  const localOnlyFilter = `AND ${LOCAL_RECORDS_WHERE}`
   const toolWhere = options?.tool ? 'AND tool = @tool' : ''
   const toolParam = options?.tool ? { tool: options.tool } : {}
   const timeWhere = [

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -10,8 +10,9 @@ import { loadConfig, buildConsentConfig, loadCredential, AIUSAGE_DIR } from '../
 import { hasCredentials } from '../leaderboard/credentials.js'
 import type { SyncProgress } from '../sync/runtime.js'
 import { getSyncTarget } from '../sync/target.js'
+import { repairSyncContamination, type RepairReport } from '../sync/repair.js'
 
-function createBackend(config: import('../config.js').Config): SyncBackend | null {
+export function createBackend(config: import('../config.js').Config): SyncBackend | null {
   const sync = config.sync
   if (!sync) return null
 
@@ -141,4 +142,100 @@ export async function runSync(
   })
 
   return result
+}
+
+export interface SyncRepairOptions {
+  /** Perform the changes; without it the report is a dry run. */
+  apply?: boolean
+  /** Also repair namespaces owned by other devices (file-based backends). */
+  allNamespaces?: boolean
+}
+
+/**
+ * `aiusage sync --repair`: analyse (and with `apply`, clean up) records that
+ * the pre-provenance sync bug copied into the wrong device namespace.
+ * See sync/repair.ts for the rules. Consent is required exactly as for sync,
+ * because repairing rewrites files in the configured remote.
+ */
+export async function runSyncRepair(
+  db: Database.Database,
+  options: SyncRepairOptions = {},
+): Promise<{ status: 'ok' | 'failed' | 'blocked_pending_consent'; report?: RepairReport; error?: string }> {
+  const config = loadConfig()
+  if (!config?.sync) {
+    return { status: 'failed', error: 'Sync not configured. Run "aiusage init" first.' }
+  }
+  const state = getState(AIUSAGE_DIR)
+  if (!state?.deviceInstanceId) {
+    return { status: 'failed', error: 'Device identity not initialised. Run "aiusage init" first.' }
+  }
+  const target = getSyncTarget(config.sync)
+  if (!target) {
+    return { status: 'failed', error: 'Invalid sync configuration.' }
+  }
+
+  // Cloud backend has no per-device namespaces: local repair only.
+  if (config.sync.backend === 'cloud') {
+    const report = await repairSyncContamination(db, { deviceInstanceId: state.deviceInstanceId, apply: options.apply })
+    return { status: 'ok', report }
+  }
+
+  const consent = state.syncConsents?.[target]
+    ?? (state.lastSyncTarget === target && state.syncConsentAt && state.syncConsentTarget
+      ? { syncConsentAt: state.syncConsentAt, syncConsentTarget: state.syncConsentTarget }
+      : null)
+  const consentConfig = buildConsentConfig(config)
+  if (!consent?.syncConsentAt || !consent?.syncConsentTarget || !consentConfig || !verifyConsent(consent.syncConsentTarget, consentConfig)) {
+    return { status: 'blocked_pending_consent', error: 'Sync consent not provided. Run "aiusage init" to approve.' }
+  }
+
+  const backend = createBackend(config)
+  if (!backend) {
+    return { status: 'failed', error: 'Could not create sync backend. Check credentials.' }
+  }
+
+  try {
+    const report = await repairSyncContamination(db, {
+      deviceInstanceId: state.deviceInstanceId,
+      backend,
+      allNamespaces: options.allNamespaces,
+      apply: options.apply,
+    })
+    return { status: 'ok', report }
+  } catch (error) {
+    return { status: 'failed', error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+/** Human-readable rendering of a repair report for the CLI. */
+export function formatRepairReport(report: RepairReport): string {
+  const lines: string[] = []
+  const verb = report.applied ? 'Removed' : 'Would remove'
+  const flag = report.applied ? 'Re-flagged' : 'Would re-flag'
+  lines.push(`Device: ${report.deviceInstanceId}`)
+  lines.push('')
+  lines.push('Local database:')
+  lines.push(`  ${flag} ${report.local.reflagRecordIds.length} record(s) still marked local that were pulled from other devices`)
+  lines.push(`  ${verb} ${report.local.echoSyncedIds.length} echoed row(s) from synced_records (copies of records that bounced through another device)`)
+  lines.push(`  ${verb} ${report.local.echoMergedIds.length} merged copy(ies) of those echoes from records`)
+  lines.push(`  ${verb} ${report.local.staleSyncStateCount} stale sync bookkeeping row(s)`)
+  if (report.remote) {
+    lines.push('')
+    lines.push(`Remote: scanned ${report.remote.scannedFiles} file(s), ${report.remote.scannedLines} line(s)`)
+    for (const ns of report.remote.namespaces) {
+      const own = ns.owner === report.deviceInstanceId ? ' (this device)' : ''
+      const bad = ns.foreignLines + ns.echoLines
+      lines.push(`  ${ns.owner}${own}: ${ns.lines} line(s) in ${ns.files} file(s), ${bad} contaminated (${ns.foreignLines} foreign-device, ${ns.echoLines} echo)`)
+    }
+    const dropped = report.remote.files.reduce((n, f) => n + f.foreignLines + f.echoLines, 0)
+    lines.push(`  ${verb} ${dropped} line(s) across ${report.remote.files.length} file(s)`)
+    if (report.remoteResult) {
+      lines.push(`  Rewrote ${report.remoteResult.rewritten} file(s), deleted ${report.remoteResult.deleted} empty file(s), ${report.remoteResult.flushed ? 'pushed' : 'nothing to push'}`)
+    }
+  }
+  if (!report.applied) {
+    lines.push('')
+    lines.push('Dry run — nothing was changed. Re-run with --apply to perform these changes.')
+  }
+  return lines.join('\n')
 }

--- a/packages/cli/src/db/migrations/index.ts
+++ b/packages/cli/src/db/migrations/index.ts
@@ -11,6 +11,7 @@ import { migrateV9 } from './v9.js'
 import { migrateV10 } from './v10.js'
 import { migrateV11 } from './v11.js'
 import { migrateV12 } from './v12.js'
+import { migrateV13 } from './v13.js'
 import { createSchemaVersionTable } from '../schema.js'
 
 const MIGRATIONS = [
@@ -26,6 +27,7 @@ const MIGRATIONS = [
   { version: 10, migrate: migrateV10 },
   { version: 11, migrate: migrateV11 },
   { version: 12, migrate: migrateV12 },
+  { version: 13, migrate: migrateV13 },
 ]
 
 export function runMigrations(db: Database.Database): void {

--- a/packages/cli/src/db/migrations/v13.ts
+++ b/packages/cli/src/db/migrations/v13.ts
@@ -1,0 +1,60 @@
+import type Database from 'better-sqlite3'
+
+/**
+ * Cross-device provenance repair (explicit `records.origin`).
+ *
+ * Records pulled from other devices are copied from `synced_records` into
+ * `records` so local queries can see them. Historically the only marker that a
+ * row in `records` was such a copy was `source_file LIKE 'synced/%'`. Once the
+ * wire format started carrying the real `source_file` (needed for cross-device
+ * project stats), that marker disappeared and pulled rows became
+ * indistinguishable from locally parsed ones: they were re-uploaded under the
+ * *pulling* device's sync namespace (with colliding ids, because merged rows
+ * have `line_offset = 0`) and double-counted in local summaries.
+ *
+ * This migration adds an explicit `origin` column ('local' | 'synced') and
+ * back-fills it deterministically. A row is classified as `synced` when:
+ *
+ *   1. it still carries the legacy `synced/<device>` placeholder source_file, or
+ *   2. a `synced_records` row with the same id exists whose `session_key`
+ *      equals the row's `session_id`.
+ *
+ * Rule 2 is the fingerprint of `mergeSyncedRecordsIntoRecords`: it is the only
+ * writer that stores the 24-hex `session_key` hash in `records.session_id`.
+ * Parsers store the tool's real session id, and no tool session id can equal
+ * `sha256(device + '\0' + sessionId)[0:24]` of another session (that would be a
+ * hash pre-image). Local rows that were later re-parsed keep their real
+ * session id and therefore stay `local`, so no legitimate local usage is hidden.
+ *
+ * `sync_record_state` rows that were created when those pulled rows were
+ * wrongly uploaded are removed so they can never be mistaken for local sync
+ * bookkeeping. Nothing else is deleted here — see `aiusage sync --repair` for
+ * the opt-in cleanup of echoed rows and contaminated remote namespaces.
+ */
+export function migrateV13(db: Database.Database): void {
+  const columns = db.prepare('PRAGMA table_info(records)').all() as Array<{ name: string }>
+  if (!columns.some(c => c.name === 'origin')) {
+    db.exec(`ALTER TABLE records ADD COLUMN origin TEXT NOT NULL DEFAULT 'local'`)
+  }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_records_origin ON records(origin)`)
+
+  db.exec(`
+    UPDATE records
+    SET origin = 'synced'
+    WHERE origin = 'local'
+      AND (
+        source_file LIKE 'synced/%'
+        OR EXISTS (
+          SELECT 1 FROM synced_records s
+          WHERE s.id = records.id AND s.session_key = records.session_id
+        )
+      )
+  `)
+
+  db.exec(`
+    DELETE FROM sync_record_state
+    WHERE record_id IN (SELECT id FROM records WHERE origin = 'synced')
+  `)
+
+  db.prepare('INSERT INTO schema_version (version) VALUES (13)').run()
+}

--- a/packages/cli/src/db/records.ts
+++ b/packages/cli/src/db/records.ts
@@ -1,5 +1,34 @@
 import type Database from 'better-sqlite3'
-import type { StatsRecord } from '@aiusage/core'
+import type { RecordOrigin, StatsRecord } from '@aiusage/core'
+
+/**
+ * Sentinel device id used by parsers that ran before `state.json` existed.
+ * Such rows were still produced on this device, so they count as local; parse
+ * re-labels them to the real device id on its next run.
+ */
+export const UNKNOWN_DEVICE_INSTANCE_ID = 'unknown'
+
+/**
+ * SQL fragment (no leading AND) selecting rows that were parsed on this device.
+ * Use this — never `source_file NOT LIKE 'synced/%'` — to exclude records that
+ * were pulled from other devices and merged into `records`.
+ */
+export const LOCAL_RECORDS_WHERE = "origin = 'local'"
+
+/**
+ * True when `record` may be uploaded under `deviceInstanceId`'s sync namespace:
+ * it must have been parsed here (origin = local) and carry this device's id
+ * (or the pre-init 'unknown' sentinel, which only local parsing can produce).
+ * Pulled records — whatever their `source_file` — never satisfy this.
+ */
+export function isUploadableLocalRecord(
+  record: Pick<StatsRecord, 'origin' | 'deviceInstanceId'>,
+  deviceInstanceId: string,
+): boolean {
+  if ((record.origin ?? 'local') !== 'local') return false
+  return record.deviceInstanceId === deviceInstanceId
+    || record.deviceInstanceId === UNKNOWN_DEVICE_INSTANCE_ID
+}
 
 export function insertRecord(db: Database.Database, record: StatsRecord): void {
   db.prepare(`
@@ -7,12 +36,12 @@ export function insertRecord(db: Database.Database, record: StatsRecord): void {
       id, ts, ingested_at, synced_at, updated_at, line_offset,
       tool, model, provider, input_tokens, output_tokens,
       cache_read_tokens, cache_write_tokens, thinking_tokens,
-      cost, cost_source, session_id, source_file, cwd, device, device_instance_id, platform
+      cost, cost_source, session_id, source_file, cwd, device, device_instance_id, platform, origin
     ) VALUES (
       @id, @ts, @ingestedAt, @syncedAt, @updatedAt, @lineOffset,
       @tool, @model, @provider, @inputTokens, @outputTokens,
       @cacheReadTokens, @cacheWriteTokens, @thinkingTokens,
-      @cost, @costSource, @sessionId, @sourceFile, @cwd, @device, @deviceInstanceId, @platform
+      @cost, @costSource, @sessionId, @sourceFile, @cwd, @device, @deviceInstanceId, @platform, @origin
     )
   `).run({
     id: record.id,
@@ -37,6 +66,7 @@ export function insertRecord(db: Database.Database, record: StatsRecord): void {
     device: record.device,
     deviceInstanceId: record.deviceInstanceId,
     platform: record.platform ?? '',
+    origin: record.origin ?? 'local',
   })
 }
 
@@ -56,18 +86,37 @@ export function deleteRecordsBySourceFile(db: Database.Database, sourceFile: str
   return result.changes
 }
 
-export function getUnsyncedRecords(db: Database.Database, target?: string): StatsRecord[] {
+/**
+ * Local records that still need uploading.
+ *
+ * Only rows with `origin = 'local'` are candidates: rows merged from
+ * `synced_records` are never returned, regardless of their `source_file`.
+ * When `deviceInstanceId` is given, candidates are additionally restricted to
+ * rows carrying that device id (or the pre-init 'unknown' sentinel), so a row
+ * stamped with another device's id can never be uploaded under this device's
+ * namespace even if its provenance flag were wrong.
+ */
+export function getUnsyncedRecords(db: Database.Database, target?: string, deviceInstanceId?: string): StatsRecord[] {
+  const ownerWhere = deviceInstanceId !== undefined
+    ? `AND r.device_instance_id IN (@deviceInstanceId, '${UNKNOWN_DEVICE_INSTANCE_ID}')`
+    : ''
+  const ownerParams = deviceInstanceId !== undefined ? { deviceInstanceId } : {}
+
   const rows = target
     ? db.prepare(`
         SELECT r.* FROM records r
         LEFT JOIN sync_record_state s
-          ON s.record_id = r.id AND s.target = ?
-        WHERE r.source_file NOT LIKE 'synced/%'
+          ON s.record_id = r.id AND s.target = @target
+        WHERE r.${LOCAL_RECORDS_WHERE}
+          ${ownerWhere}
           AND (s.synced_at IS NULL OR r.updated_at > s.synced_at)
-      `).all(target) as Record<string, unknown>[]
-    : db.prepare(
-      'SELECT * FROM records WHERE synced_at IS NULL OR updated_at > synced_at'
-    ).all() as Record<string, unknown>[]
+      `).all({ target, ...ownerParams }) as Record<string, unknown>[]
+    : db.prepare(`
+        SELECT r.* FROM records r
+        WHERE r.${LOCAL_RECORDS_WHERE}
+          ${ownerWhere}
+          AND (r.synced_at IS NULL OR r.updated_at > r.synced_at)
+      `).all(ownerParams) as Record<string, unknown>[]
   return rows.map(mapRowToRecord)
 }
 
@@ -98,6 +147,35 @@ export function markRecordsSynced(db: Database.Database, ids: string[], syncedAt
   tx(ids)
 }
 
+/**
+ * Runtime provenance guard, run at the start of every sync once the current
+ * device id is known (migrations cannot know it).
+ *
+ * Any `origin = 'local'` row stamped with a *different, concrete* device id
+ * cannot have been produced by a parser on this device — parsers always stamp
+ * the current id (or 'unknown' before init). Such rows are pulled copies whose
+ * merge fingerprint was lost (e.g. the origin device renamed its alias and
+ * re-uploaded, changing the session key), so they are re-flagged as `synced`.
+ * Nothing is deleted; the rows remain visible via `synced_records`.
+ * Returns the number of rows re-flagged.
+ */
+export function repairRecordProvenance(db: Database.Database, deviceInstanceId: string): number {
+  const result = db.prepare(`
+    UPDATE records
+    SET origin = 'synced'
+    WHERE origin = 'local'
+      AND device_instance_id != ?
+      AND device_instance_id != '${UNKNOWN_DEVICE_INSTANCE_ID}'
+  `).run(deviceInstanceId)
+  if (result.changes > 0) {
+    db.prepare(`
+      DELETE FROM sync_record_state
+      WHERE record_id IN (SELECT id FROM records WHERE origin = 'synced')
+    `).run()
+  }
+  return result.changes
+}
+
 function mapRowToRecord(row: Record<string, unknown>): StatsRecord {
   return {
     id: row.id as string,
@@ -122,5 +200,6 @@ function mapRowToRecord(row: Record<string, unknown>): StatsRecord {
     device: row.device as string,
     deviceInstanceId: row.device_instance_id as string,
     platform: (row.platform as string) || undefined,
+    origin: ((row.origin as string) || 'local') as RecordOrigin,
   }
 }

--- a/packages/cli/src/db/synced-records.ts
+++ b/packages/cli/src/db/synced-records.ts
@@ -69,15 +69,26 @@ export function getSyncedRecordById(db: Database.Database, id: string): SyncReco
 /**
  * Merge synced_records into records table so API queries can see them.
  * Only inserts records that don't already exist in records.
+ *
+ * Every row written here is stamped `origin = 'synced'` — that flag, not the
+ * `source_file` value, is what marks it as pulled. `source_file` and `cwd`
+ * are copied verbatim so cross-device project stats keep working.
+ *
+ * Rows carrying `currentDeviceInstanceId` (when given) are skipped: a copy of
+ * this device's own record can only reach `synced_records` by being echoed
+ * through another device's namespace, and the authoritative row already lives
+ * in `records` with `origin = 'local'`.
+ *
  * Returns the number of newly inserted records.
  */
-export function mergeSyncedRecordsIntoRecords(db: Database.Database): number {
+export function mergeSyncedRecordsIntoRecords(db: Database.Database, currentDeviceInstanceId?: string): number {
   const now = Date.now()
+  const ownFilter = currentDeviceInstanceId !== undefined ? 'AND sr.device_instance_id != @currentDeviceInstanceId' : ''
   const newRows = db.prepare(`
     SELECT sr.* FROM synced_records sr
     LEFT JOIN records r ON sr.id = r.id
-    WHERE r.id IS NULL
-  `).all() as Record<string, unknown>[]
+    WHERE r.id IS NULL ${ownFilter}
+  `).all(currentDeviceInstanceId !== undefined ? { currentDeviceInstanceId } : {}) as Record<string, unknown>[]
 
   if (newRows.length === 0) return 0
 
@@ -86,12 +97,12 @@ export function mergeSyncedRecordsIntoRecords(db: Database.Database): number {
       id, ts, ingested_at, synced_at, updated_at, line_offset,
       tool, model, provider, input_tokens, output_tokens,
       cache_read_tokens, cache_write_tokens, thinking_tokens,
-      cost, cost_source, session_id, source_file, device, device_instance_id
+      cost, cost_source, session_id, source_file, cwd, device, device_instance_id, platform, origin
     ) VALUES (
       @id, @ts, @ingestedAt, @syncedAt, @updatedAt, 0,
       @tool, @model, @provider, @inputTokens, @outputTokens,
       @cacheReadTokens, @cacheWriteTokens, @thinkingTokens,
-      @cost, @costSource, @sessionId, @sourceFile, @device, @deviceInstanceId
+      @cost, @costSource, @sessionId, @sourceFile, @cwd, @device, @deviceInstanceId, @platform, 'synced'
     )
   `)
 
@@ -118,9 +129,10 @@ export function mergeSyncedRecordsIntoRecords(db: Database.Database): number {
         costSource: row.cost_source,
         sessionId: row.session_key,
         sourceFile,
+        cwd: (typeof row.cwd === 'string' ? row.cwd : '') || '',
         device: row.device,
         deviceInstanceId: row.device_instance_id,
-        cwd: (typeof row.cwd === 'string' ? row.cwd : '') || '',
+        platform: (typeof row.platform === 'string' ? row.platform : '') || '',
       })
     }
   })

--- a/packages/cli/src/sync/cloud-orchestrator.ts
+++ b/packages/cli/src/sync/cloud-orchestrator.ts
@@ -1,6 +1,6 @@
 import type Database from 'better-sqlite3'
 import type { SyncRecord, SyncTombstone } from '@aiusage/core'
-import { getUnsyncedRecords, markRecordsSynced } from '../db/records.js'
+import { getUnsyncedRecords, isUploadableLocalRecord, markRecordsSynced, repairRecordProvenance } from '../db/records.js'
 import { insertSyncedRecord, mergeSyncedRecordsIntoRecords } from '../db/synced-records.js'
 import { mapStatsRecordToSyncRecord } from './mapper.js'
 import { cloudPush, cloudPull, CloudSyncError } from './cloud.js'
@@ -32,13 +32,22 @@ export class CloudSyncOrchestrator {
 
   async sync(syncGeneration: number = 1): Promise<CloudSyncResult> {
     try {
+      // Step 0: provenance guard — rows stamped with another device's id are
+      // never local, whatever their source_file says.
+      repairRecordProvenance(this.db, this.options.deviceInstanceId)
+
       // Step 1: Pull records from other devices
       this.options.onProgress?.({ phase: 'pulling', pulledCount: 0 })
       const pullResult = await this.pullAll(syncGeneration)
 
-      // Step 2: Insert pulled records into synced_records
+      // Step 2: Insert pulled records into synced_records.
+      // The server returns every device's records, including our own. Our own
+      // rows already live in `records` (origin = local) — and for tools whose
+      // local id differs from the wire id (e.g. Claude Code message ids) they
+      // would otherwise be merged back as fresh "local" rows and re-pushed.
       let insertedCount = 0
       for (const record of pullResult.records) {
+        if (record.deviceInstanceId === this.options.deviceInstanceId) continue
         try {
           insertSyncedRecord(this.db, record)
           insertedCount++
@@ -47,7 +56,7 @@ export class CloudSyncOrchestrator {
 
       // Step 3: Merge synced_records into records
       this.options.onProgress?.({ phase: 'merging', pulledCount: insertedCount })
-      const mergedCount = mergeSyncedRecordsIntoRecords(this.db)
+      const mergedCount = mergeSyncedRecordsIntoRecords(this.db, this.options.deviceInstanceId)
 
       // Step 4: Push local records to cloud
       this.options.onProgress?.({ phase: 'uploading', pulledCount: insertedCount })
@@ -55,7 +64,7 @@ export class CloudSyncOrchestrator {
 
       // Step 5: Mark local records as synced
       const target = this.options.target ?? 'cloud'
-      const unsynced = getUnsyncedRecords(this.db, target)
+      const unsynced = this.getUploadableRecords(target)
       if (unsynced.length > 0) {
         markRecordsSynced(this.db, unsynced.map(r => r.id), Date.now(), target)
       }
@@ -104,8 +113,19 @@ export class CloudSyncOrchestrator {
     return { records: allRecords, syncGeneration }
   }
 
+  /**
+   * Local rows eligible for push: parsed on this device and stamped with its
+   * id. The query filters on provenance; the explicit predicate is the final
+   * guard so nothing pulled from another device is ever pushed as ours.
+   */
+  private getUploadableRecords(target: string) {
+    const deviceInstanceId = this.options.deviceInstanceId
+    return getUnsyncedRecords(this.db, target, deviceInstanceId)
+      .filter(record => isUploadableLocalRecord(record, deviceInstanceId))
+  }
+
   private async push(syncGeneration: number): Promise<number> {
-    const unsynced = getUnsyncedRecords(this.db, this.options.target ?? 'cloud')
+    const unsynced = this.getUploadableRecords(this.options.target ?? 'cloud')
     if (unsynced.length === 0) {
       return 0
     }

--- a/packages/cli/src/sync/index.ts
+++ b/packages/cli/src/sync/index.ts
@@ -1,8 +1,9 @@
 import type Database from 'better-sqlite3'
 import type { SyncRecord } from '@aiusage/core'
-import { getUnsyncedRecords, markRecordsSynced } from '../db/records.js'
+import { getUnsyncedRecords, isUploadableLocalRecord, markRecordsSynced, repairRecordProvenance } from '../db/records.js'
 import { insertSyncedRecord, mergeSyncedRecordsIntoRecords } from '../db/synced-records.js'
 import { mapStatsRecordToSyncRecord } from './mapper.js'
+import { classifyPulledRecord, namespaceOwnerFromPath } from './ownership.js'
 import type { SyncProgress } from './runtime.js'
 
 export interface SyncBackend {
@@ -31,6 +32,15 @@ export interface SyncResult {
   pulledCount: number
   uploadedCount: number
   mergedCount: number
+  /**
+   * Remote lines ignored during pull because they did not belong to the
+   * namespace they were read from (or were echoes of this device's own
+   * records). Non-zero means a peer still has a contaminated namespace —
+   * see `aiusage sync --repair`.
+   */
+  ignoredCount?: number
+  /** Local rows whose provenance flag was corrected before uploading. */
+  repairedCount?: number
   error?: string
 }
 
@@ -40,20 +50,29 @@ export function getSyncPath(ts: string | number, deviceInstanceId: string): stri
   return `${deviceInstanceId}/${date}.ndjson`
 }
 
+/** Parse a single ndjson line, normalising string timestamps. Returns null on bad input. */
+export function parseSyncRecordLine(line: string): SyncRecord | null {
+  try {
+    const record: SyncRecord = JSON.parse(line)
+    if (!record || typeof record !== 'object' || typeof record.id !== 'string') return null
+    if (typeof record.ts === 'string') {
+      (record as any).ts = new Date(record.ts).getTime()
+    }
+    if (typeof record.updatedAt === 'string') {
+      (record as any).updatedAt = new Date(record.updatedAt).getTime()
+    }
+    return record
+  } catch {
+    return null
+  }
+}
+
 /** Parse ndjson content into a Map<id, SyncRecord> */
-function parseNdjson(content: string): Map<string, SyncRecord> {
+export function parseNdjson(content: string): Map<string, SyncRecord> {
   const records = new Map<string, SyncRecord>()
   for (const line of content.split('\n').filter(Boolean)) {
-    try {
-      const record: SyncRecord = JSON.parse(line)
-      if (typeof record.ts === 'string') {
-        (record as any).ts = new Date(record.ts).getTime()
-      }
-      if (typeof record.updatedAt === 'string') {
-        (record as any).updatedAt = new Date(record.updatedAt).getTime()
-      }
-      records.set(record.id, record)
-    } catch {}
+    const record = parseSyncRecordLine(line)
+    if (record) records.set(record.id, record)
   }
   return records
 }
@@ -91,14 +110,17 @@ export class SyncOrchestrator {
     }
 
     try {
+      // Provenance guard first: nothing stamped with another device's id may
+      // ever be treated as local, whatever its source_file says.
+      const repairedCount = repairRecordProvenance(this.db, this.options.deviceInstanceId)
       await this.backend.prepare?.()
-      const pulledCount = await this.pull()
+      const { pulledCount, ignoredCount } = await this.pull()
       this.options.onProgress?.({ phase: 'merging', pulledCount })
-      const mergedCount = mergeSyncedRecordsIntoRecords(this.db)
+      const mergedCount = mergeSyncedRecordsIntoRecords(this.db, this.options.deviceInstanceId)
       const uploadedCount = await this.upload()
       await this.backend.flush?.()
       this.options.onProgress?.({ phase: 'finalizing', pulledCount, uploadedCount })
-      return { status: 'ok', pulledCount, uploadedCount, mergedCount }
+      return { status: 'ok', pulledCount, uploadedCount, mergedCount, ignoredCount, repairedCount }
     } catch (error) {
       return {
         status: 'failed',
@@ -110,7 +132,7 @@ export class SyncOrchestrator {
     }
   }
 
-  private async pull(): Promise<number> {
+  private async pull(): Promise<{ pulledCount: number; ignoredCount: number }> {
     const allPaths = await this.backend.listFiles()
     const localDevicePrefix = `${this.options.deviceInstanceId}/`
     const paths = allPaths.filter(p => !p.startsWith(localDevicePrefix))
@@ -121,9 +143,10 @@ export class SyncOrchestrator {
       totalFiles: paths.length,
       pulledCount: 0,
     })
-    if (paths.length === 0) return 0
+    if (paths.length === 0) return { pulledCount: 0, ignoredCount: 0 }
 
     let totalPulled = 0
+    let totalIgnored = 0
 
     for (const [index, path] of paths.entries()) {
       this.options.onProgress?.({
@@ -136,15 +159,18 @@ export class SyncOrchestrator {
       const content = await this.backend.readFile(path)
       if (!content) continue
 
+      const namespaceOwner = namespaceOwnerFromPath(path)
       for (const line of content.split('\n').filter(Boolean)) {
+        const record = parseSyncRecordLine(line)
+        if (!record) continue
+        // Only records that belong to the namespace they were read from are
+        // trusted. Anything else is a pre-fix echo whose authoritative copy
+        // lives elsewhere (or is our own local row).
+        if (classifyPulledRecord(record, namespaceOwner, this.options.deviceInstanceId)) {
+          totalIgnored++
+          continue
+        }
         try {
-          const record: SyncRecord = JSON.parse(line)
-          if (typeof record.ts === 'string') {
-            (record as any).ts = new Date(record.ts).getTime()
-          }
-          if (typeof record.updatedAt === 'string') {
-            (record as any).updatedAt = new Date(record.updatedAt).getTime()
-          }
           const changed = insertSyncedRecord(this.db, record)
           if (changed) totalPulled++
         } catch {}
@@ -159,7 +185,7 @@ export class SyncOrchestrator {
       })
     }
 
-    return totalPulled
+    return { pulledCount: totalPulled, ignoredCount: totalIgnored }
   }
 
   private async uploadFile(
@@ -178,13 +204,18 @@ export class SyncOrchestrator {
   }
 
   private async upload(): Promise<number> {
-    const unsynced = getUnsyncedRecords(this.db, this.options.target)
+    const deviceInstanceId = this.options.deviceInstanceId
+    // The query already restricts to origin = 'local' rows owned by this
+    // device; the explicit filter is the last line of defence so that no
+    // record stamped with another device's id can reach our namespace.
+    const unsynced = getUnsyncedRecords(this.db, this.options.target, deviceInstanceId)
+      .filter(record => isUploadableLocalRecord(record, deviceInstanceId))
     if (unsynced.length === 0) return 0
 
-    // Group records by day per device.
+    // Group records by day. Every path is under *this* device's namespace.
     const byPath = new Map<string, typeof unsynced>()
     for (const record of unsynced) {
-      const path = getSyncPath(record.ts, this.options.deviceInstanceId)
+      const path = getSyncPath(record.ts, deviceInstanceId)
       if (!byPath.has(path)) byPath.set(path, [])
       byPath.get(path)!.push(record)
     }

--- a/packages/cli/src/sync/mapper.ts
+++ b/packages/cli/src/sync/mapper.ts
@@ -18,12 +18,15 @@ const RECORD_ID_SYNC_TOOLS = new Set<Tool>([
 ])
 
 export function mapStatsRecordToSyncRecord(record: StatsRecord): SyncRecord {
-  // Records merged from synced_records have source_file='synced/<deviceId>' and lineOffset=0,
-  // which would cause all records from the same device to collide to one ID.
-  // Use the existing record ID directly for these — it's already a valid sync record ID.
+  // Records merged from synced_records already carry their wire-format id and
+  // have lineOffset=0, so regenerating the id from (device, sourceFile, 0)
+  // would collapse every record of a source file into one id. Their
+  // provenance is the explicit `origin` flag — never the source_file value.
+  // (Such records are never uploaded; this keeps the id stable if they are
+  // ever mapped, e.g. for export.)
   // Several imports use database rows or JSON-array indexes, where lineOffset is not a
   // stable byte position. Use record.id because those parsers already encode row/session identity.
-  const id = record.sourceFile.startsWith('synced/')
+  const id = record.origin === 'synced'
     ? record.id
     : RECORD_ID_SYNC_TOOLS.has(record.tool)
       ? record.id

--- a/packages/cli/src/sync/ownership.ts
+++ b/packages/cli/src/sync/ownership.ts
@@ -1,0 +1,47 @@
+import type { SyncRecord } from '@aiusage/core'
+import { UNKNOWN_DEVICE_INSTANCE_ID } from '../db/records.js'
+
+/**
+ * Namespace ownership rules for the file-based sync backends (GitHub, S3, …).
+ *
+ * Every data file lives under `<deviceInstanceId>/YYYY/MM/DD.ndjson`; the first
+ * path segment is the namespace *owner*. The invariant enforced by the
+ * orchestrator is:
+ *
+ *   A record may only be written under the namespace of the device that
+ *   parsed it, and a device only reads records that belong to the namespace
+ *   they were read from.
+ *
+ * A line whose `deviceInstanceId` names a *different, concrete* device than
+ * the namespace it sits in can only have been produced by the pre-fix bug
+ * (a pulled record re-uploaded as if it were local). Its authoritative copy
+ * lives in that other device's own namespace, so it is ignored on pull.
+ *
+ * The pre-init `'unknown'` sentinel (and an empty id from very old clients)
+ * is accepted as belonging to the namespace owner — those records were
+ * produced by that device before `state.json` existed.
+ */
+
+export function namespaceOwnerFromPath(path: string): string {
+  const idx = path.indexOf('/')
+  return idx === -1 ? path : path.slice(0, idx)
+}
+
+export type PulledRecordRejection = 'own-device-echo' | 'foreign-namespace'
+
+/**
+ * Decide whether a record read from `namespaceOwner`'s files should be stored
+ * in `synced_records`. Returns `null` to accept, or the rejection reason.
+ */
+export function classifyPulledRecord(
+  record: Pick<SyncRecord, 'deviceInstanceId'>,
+  namespaceOwner: string,
+  ownDeviceInstanceId: string,
+): PulledRecordRejection | null {
+  const did = record.deviceInstanceId
+  // A copy of our own record can only come back through another namespace.
+  if (did === ownDeviceInstanceId) return 'own-device-echo'
+  if (!did || did === UNKNOWN_DEVICE_INSTANCE_ID) return null
+  if (did !== namespaceOwner) return 'foreign-namespace'
+  return null
+}

--- a/packages/cli/src/sync/repair.ts
+++ b/packages/cli/src/sync/repair.ts
@@ -1,0 +1,343 @@
+import type Database from 'better-sqlite3'
+import type { SyncRecord } from '@aiusage/core'
+import { generateSessionKey } from '@aiusage/core'
+import { UNKNOWN_DEVICE_INSTANCE_ID } from '../db/records.js'
+import type { SyncBackend } from './index.js'
+import { parseSyncRecordLine } from './index.js'
+import { namespaceOwnerFromPath } from './ownership.js'
+
+/**
+ * Opt-in cleanup of state left behind by the cross-device re-upload bug.
+ *
+ * Before `records.origin` existed, records pulled from device A were merged
+ * into device B's `records` table and — because their `source_file` no longer
+ * started with `synced/` — re-uploaded under B's namespace as if B had
+ * produced them. Each such round trip produced an *echo*: a copy of the record
+ * with a colliding id (`sha256(A, sourceFile, 0)`) and a session key that is
+ * the hash of the original's session key. Echoes bounced back to A and to any
+ * third device, double-counting usage everywhere.
+ *
+ * Nothing in this module runs automatically. `aiusage sync --repair` reports
+ * what would change; `--apply` performs it. Every rule below is deterministic:
+ *
+ *  - **foreign-namespace line**: a remote line whose `deviceInstanceId` is a
+ *    concrete id different from the namespace it sits in. Only the owning
+ *    device ever writes to a namespace, and post-fix it only writes its own
+ *    records, so such a line can only be a pre-fix echo. Its authoritative copy
+ *    is in the other device's namespace.
+ *  - **echo (session-key chain)**: a row/line E for which a known session key
+ *    K exists such that `generateSessionKey(E.device, K) === E.sessionKey`. The mapper
+ *    derives a wire session key as `sha256(device + '\0' + sessionId)[0:24]`;
+ *    a merged row's `session_id` *is* the parent's session key, so re-uploading
+ *    it hashes the hash. A genuine record's session id is a tool-generated
+ *    identifier, never another session's 24-hex hash, so this relation cannot
+ *    hold by accident.
+ *  - **own-device echo**: a `synced_records` row stamped with this device's own
+ *    id. Pull never reads our own namespace, so our id can only appear there by
+ *    bouncing through another device. The authoritative row is in `records`.
+ *
+ * Deleting an echo never loses usage: by construction the parent it was
+ * derived from still exists (or is itself an echo whose parent exists).
+ */
+
+/**
+ * Every session key known to the system (local rows, pulled rows, remote
+ * lines). A record is an echo when its session key is the hash of one of
+ * these keys under its own device alias — the exact transformation the mapper
+ * applies when a merged row (whose `session_id` is already a key) is
+ * re-uploaded. Usage fields are deliberately not compared: backfills rewrite
+ * model/cost/timestamps on the origin device after an echo was taken, and the
+ * chain relation alone is already a hash pre-image argument.
+ */
+export class SessionKeyChain {
+  private readonly keys = new Set<string>()
+  /** device alias → { generateSessionKey(alias, k) : k ∈ keys }, built lazily. */
+  private readonly hashedByDevice = new Map<string, Set<string>>()
+
+  add(sessionKey: string): void {
+    if (!sessionKey) return
+    if (!this.keys.has(sessionKey)) {
+      this.keys.add(sessionKey)
+      this.hashedByDevice.clear()
+    }
+  }
+
+  get size(): number {
+    return this.keys.size
+  }
+
+  /** True when `record.sessionKey` is `generateSessionKey(record.device, k)` for a known key `k`. */
+  isEcho(record: { device: string; sessionKey: string }): boolean {
+    if (!record.sessionKey) return false
+    let hashed = this.hashedByDevice.get(record.device)
+    if (!hashed) {
+      hashed = new Set()
+      for (const k of this.keys) hashed.add(generateSessionKey(record.device, k))
+      this.hashedByDevice.set(record.device, hashed)
+    }
+    return hashed.has(record.sessionKey)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local database
+// ---------------------------------------------------------------------------
+
+export interface LocalRepairPlan {
+  /** `records` rows still flagged local that are provably pulled copies. */
+  reflagRecordIds: string[]
+  /** `synced_records` rows that are echoes (own-device or chain). */
+  echoSyncedIds: string[]
+  /** `records` rows (origin = synced) that were merged from those echoes. */
+  echoMergedIds: string[]
+  /** `sync_record_state` rows attached to non-local records. */
+  staleSyncStateCount: number
+}
+
+interface SyncedRow {
+  id: string
+  device: string
+  device_instance_id: string
+  session_key: string
+}
+
+/**
+ * Collect every session key this device knows about: its own local rows
+ * (wire key = hash(device, sessionId)), all pulled rows, and — when provided —
+ * every line read from the remote backend.
+ */
+function buildSessionKeyChain(db: Database.Database, remoteLines?: Iterable<SyncRecord>): SessionKeyChain {
+  const chain = new SessionKeyChain()
+  const localRows = db.prepare(`
+    SELECT DISTINCT device, session_id FROM records WHERE origin = 'local'
+  `).all() as Array<{ device: string; session_id: string }>
+  for (const r of localRows) chain.add(generateSessionKey(r.device, r.session_id))
+  const syncedRows = db.prepare(`SELECT DISTINCT session_key FROM synced_records`).all() as Array<{ session_key: string }>
+  for (const r of syncedRows) chain.add(r.session_key)
+  if (remoteLines) {
+    for (const line of remoteLines) chain.add(line.sessionKey)
+  }
+  return chain
+}
+
+export function planLocalRepair(
+  db: Database.Database,
+  deviceInstanceId: string,
+  remoteLines?: Iterable<SyncRecord>,
+): LocalRepairPlan {
+  // 1. Provenance: local-flagged rows that are provably pulled copies.
+  const reflagRows = db.prepare(`
+    SELECT id FROM records
+    WHERE origin = 'local'
+      AND (
+        source_file LIKE 'synced/%'
+        OR (device_instance_id != @deviceInstanceId AND device_instance_id != '${UNKNOWN_DEVICE_INSTANCE_ID}')
+        OR EXISTS (
+          SELECT 1 FROM synced_records s
+          WHERE s.id = records.id AND s.session_key = records.session_id
+        )
+      )
+  `).all({ deviceInstanceId }) as Array<{ id: string }>
+  const reflagRecordIds = reflagRows.map(r => r.id)
+
+  // 2. Echoes in synced_records.
+  const chain = buildSessionKeyChain(db, remoteLines)
+  const syncedRows = db.prepare(`
+    SELECT id, device, device_instance_id, session_key FROM synced_records
+  `).all() as SyncedRow[]
+  const echoSyncedIds: string[] = []
+  for (const row of syncedRows) {
+    const ownDevice = row.device_instance_id === deviceInstanceId
+    const echoed = chain.isEcho({ device: row.device, sessionKey: row.session_key })
+    if (ownDevice || echoed) echoSyncedIds.push(row.id)
+  }
+
+  // 3. records rows merged from those echoes (never local: origin = synced,
+  //    or about to be re-flagged as such).
+  const echoSet = new Set(echoSyncedIds)
+  const reflagSet = new Set(reflagRecordIds)
+  const mergedRows = db.prepare(`SELECT id, origin FROM records`).all() as Array<{ id: string; origin: string }>
+  const echoMergedIds = mergedRows
+    .filter(r => echoSet.has(r.id) && (r.origin === 'synced' || reflagSet.has(r.id)))
+    .map(r => r.id)
+
+  // 4. Stale sync bookkeeping.
+  const stale = db.prepare(`
+    SELECT COUNT(*) AS n FROM sync_record_state
+    WHERE record_id IN (SELECT id FROM records WHERE origin = 'synced')
+  `).get() as { n: number }
+
+  return { reflagRecordIds, echoSyncedIds, echoMergedIds, staleSyncStateCount: stale.n + reflagRecordIds.length }
+}
+
+export function applyLocalRepair(db: Database.Database, plan: LocalRepairPlan): void {
+  const reflag = db.prepare(`UPDATE records SET origin = 'synced' WHERE id = ?`)
+  const delMerged = db.prepare(`DELETE FROM records WHERE id = ? AND origin = 'synced'`)
+  const delSynced = db.prepare(`DELETE FROM synced_records WHERE id = ?`)
+  db.transaction(() => {
+    for (const id of plan.reflagRecordIds) reflag.run(id)
+    for (const id of plan.echoMergedIds) delMerged.run(id)
+    for (const id of plan.echoSyncedIds) delSynced.run(id)
+    db.prepare(`
+      DELETE FROM sync_record_state
+      WHERE record_id IN (SELECT id FROM records WHERE origin = 'synced')
+         OR record_id NOT IN (SELECT id FROM records)
+    `).run()
+  })()
+}
+
+// ---------------------------------------------------------------------------
+// Remote namespaces (file-based backends)
+// ---------------------------------------------------------------------------
+
+export interface RemoteFilePlan {
+  path: string
+  owner: string
+  totalLines: number
+  foreignLines: number
+  echoLines: number
+  /** Lines that survive; the file is deleted when this is empty. */
+  keptLines: string[]
+}
+
+export interface RemoteRepairPlan {
+  scannedFiles: number
+  scannedLines: number
+  /** Every parsed line across all namespaces (used to seed the local parent index). */
+  allRecords: SyncRecord[]
+  files: RemoteFilePlan[]
+  namespaces: Array<{ owner: string; files: number; lines: number; foreignLines: number; echoLines: number }>
+}
+
+export interface RemoteRepairOptions {
+  deviceInstanceId: string
+  /** Repair every namespace, not just this device's own. */
+  allNamespaces?: boolean
+  /** Extra known session keys (e.g. this device's local rows) to recognise echoes of. */
+  sessionKeys?: SessionKeyChain
+}
+
+export async function planRemoteRepair(backend: SyncBackend, options: RemoteRepairOptions): Promise<RemoteRepairPlan> {
+  const paths = await backend.listFiles()
+  const chain = options.sessionKeys ?? new SessionKeyChain()
+  const parsed: Array<{ path: string; owner: string; lines: Array<{ raw: string; record: SyncRecord | null }> }> = []
+  const allRecords: SyncRecord[] = []
+
+  for (const path of paths) {
+    const content = await backend.readFile(path)
+    if (!content) continue
+    const owner = namespaceOwnerFromPath(path)
+    const lines = content.split('\n').filter(Boolean).map(raw => {
+      const record = parseSyncRecordLine(raw)
+      if (record) {
+        chain.add(record.sessionKey)
+        allRecords.push(record)
+      }
+      return { raw, record }
+    })
+    parsed.push({ path, owner, lines })
+  }
+
+  const files: RemoteFilePlan[] = []
+  const perNamespace = new Map<string, { owner: string; files: number; lines: number; foreignLines: number; echoLines: number }>()
+
+  for (const file of parsed) {
+    const repairable = options.allNamespaces || file.owner === options.deviceInstanceId
+    const ns = perNamespace.get(file.owner) ?? { owner: file.owner, files: 0, lines: 0, foreignLines: 0, echoLines: 0 }
+    ns.files++
+    ns.lines += file.lines.length
+    perNamespace.set(file.owner, ns)
+
+    let foreignLines = 0
+    let echoLines = 0
+    const keptLines: string[] = []
+    for (const { raw, record } of file.lines) {
+      if (!record) { keptLines.push(raw); continue }
+      const did = record.deviceInstanceId
+      const foreign = !!did && did !== UNKNOWN_DEVICE_INSTANCE_ID && did !== file.owner
+      const echo = !foreign && chain.isEcho(record)
+      if (foreign) foreignLines++
+      else if (echo) echoLines++
+      else keptLines.push(raw)
+    }
+    ns.foreignLines += foreignLines
+    ns.echoLines += echoLines
+    if (repairable && (foreignLines > 0 || echoLines > 0)) {
+      files.push({ path: file.path, owner: file.owner, totalLines: file.lines.length, foreignLines, echoLines, keptLines })
+    }
+  }
+
+  return {
+    scannedFiles: parsed.length,
+    scannedLines: allRecords.length,
+    allRecords,
+    files,
+    namespaces: Array.from(perNamespace.values()).sort((a, b) => a.owner.localeCompare(b.owner)),
+  }
+}
+
+export async function applyRemoteRepair(backend: SyncBackend, plan: RemoteRepairPlan): Promise<{ rewritten: number; deleted: number }> {
+  let rewritten = 0
+  let deleted = 0
+  for (const file of plan.files) {
+    if (file.keptLines.length === 0 && backend.deleteFile) {
+      await backend.deleteFile(file.path)
+      deleted++
+    } else {
+      await backend.writeFile(file.path, file.keptLines.length ? file.keptLines.join('\n') + '\n' : '')
+      rewritten++
+    }
+  }
+  return { rewritten, deleted }
+}
+
+// ---------------------------------------------------------------------------
+// Combined entry point
+// ---------------------------------------------------------------------------
+
+export interface RepairReport {
+  deviceInstanceId: string
+  local: LocalRepairPlan
+  remote: RemoteRepairPlan | null
+  applied: boolean
+  remoteResult?: { rewritten: number; deleted: number; flushed: boolean }
+}
+
+export interface RepairOptions {
+  deviceInstanceId: string
+  /** File-based backend; omit for cloud (local repair only). */
+  backend?: SyncBackend
+  allNamespaces?: boolean
+  apply?: boolean
+}
+
+/**
+ * Analyse (and optionally repair) contamination. Remote lines are read first
+ * so that local echo detection can see parents that only exist remotely.
+ */
+export async function repairSyncContamination(db: Database.Database, options: RepairOptions): Promise<RepairReport> {
+  const { deviceInstanceId, backend } = options
+  let remote: RemoteRepairPlan | null = null
+
+  if (backend) {
+    await backend.prepare?.()
+    // Seed the remote echo check with this device's local rows: an echo of a
+    // record that was only ever uploaded from here still has its parent here.
+    const sessionKeys = buildSessionKeyChain(db)
+    remote = await planRemoteRepair(backend, { deviceInstanceId, allNamespaces: options.allNamespaces, sessionKeys })
+  }
+
+  const local = planLocalRepair(db, deviceInstanceId, remote?.allRecords)
+  const report: RepairReport = { deviceInstanceId, local, remote, applied: false }
+
+  if (!options.apply) return report
+
+  applyLocalRepair(db, local)
+  if (backend && remote) {
+    const result = await applyRemoteRepair(backend, remote)
+    const flushed = remote.files.length > 0 ? (await backend.flush?.()) ?? false : false
+    report.remoteResult = { ...result, flushed }
+  }
+  report.applied = true
+  return report
+}

--- a/packages/cli/tests/commands/status.test.ts
+++ b/packages/cli/tests/commands/status.test.ts
@@ -21,7 +21,7 @@ describe('Status Command', () => {
     expect(status.deviceName).toBeDefined()
     expect(status.dbPath).toBe(':memory:')
     expect(status.databaseSize).toBeDefined()
-    expect(status.schemaVersion).toBe(12)
+    expect(status.schemaVersion).toBe(13)
     expect(status.tableCount).toBeGreaterThan(0)
     expect(status.viewCount).toBe(3)
     expect(status.recordCount).toBe(0)

--- a/packages/cli/tests/db/migration-v13.test.ts
+++ b/packages/cli/tests/db/migration-v13.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { generateSessionKey } from '@aiusage/core'
+import type { StatsRecord, SyncRecord } from '@aiusage/core'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord, getUnsyncedRecords, markRecordsSynced } from '../../src/db/records.js'
+import { insertSyncedRecord } from '../../src/db/synced-records.js'
+import { migrateV13 } from '../../src/db/migrations/v13.js'
+
+// v13 introduces `records.origin` and back-fills it from the only deterministic
+// fingerprint an old merged row carries: its `session_id` equals the
+// `session_key` of the `synced_records` row with the same id.
+
+function makeRecord(overrides: Partial<StatsRecord>): StatsRecord {
+  return {
+    id: 'rec',
+    ts: 1000,
+    ingestedAt: 1000,
+    updatedAt: 1000,
+    lineOffset: 0,
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0,
+    costSource: 'pricing',
+    sessionId: 'sess-uuid',
+    sourceFile: 'C:\\Users\\alice\\.claude\\projects\\p\\s.jsonl',
+    cwd: 'C:\\Users\\alice\\proj',
+    device: 'G14',
+    deviceInstanceId: 'device-a',
+    ...overrides,
+  }
+}
+
+function makeSynced(overrides: Partial<SyncRecord>): SyncRecord {
+  return {
+    id: 'rec',
+    ts: 1000,
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0,
+    costSource: 'pricing',
+    sessionKey: generateSessionKey('G14', 'sess-uuid'),
+    device: 'G14',
+    deviceInstanceId: 'device-a',
+    updatedAt: 1000,
+    sourceFile: 'C:\\Users\\alice\\.claude\\projects\\p\\s.jsonl',
+    cwd: 'C:\\Users\\alice\\proj',
+    ...overrides,
+  }
+}
+
+describe('migration v13 (records.origin provenance)', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    initializeDatabase(db)
+    // Roll back to the pre-v13 shape: drop the column by recreating the table
+    // is heavy, so instead reset every row to 'local' and re-run the backfill.
+    db.prepare('DELETE FROM schema_version WHERE version = 13').run()
+  })
+
+  afterEach(() => db.close())
+
+  function rerun() {
+    db.prepare(`UPDATE records SET origin = 'local'`).run()
+    migrateV13(db)
+  }
+
+  it('is idempotent on the column and index', () => {
+    migrateV13(db)
+    db.prepare('DELETE FROM schema_version WHERE version = 13').run()
+    expect(() => migrateV13(db)).not.toThrow()
+    const cols = (db.prepare('PRAGMA table_info(records)').all() as any[]).filter(c => c.name === 'origin')
+    expect(cols).toHaveLength(1)
+    expect(cols[0].dflt_value).toBe("'local'")
+  })
+
+  it('flags legacy synced/<device> placeholder rows', () => {
+    insertRecord(db, makeRecord({ id: 'legacy', sourceFile: 'synced/device-b', deviceInstanceId: 'device-b' }))
+    rerun()
+    expect(db.prepare('SELECT origin FROM records WHERE id = ?').get('legacy')).toEqual({ origin: 'synced' })
+  })
+
+  it('flags rows merged from synced_records with a real source_file (the fingerprint)', () => {
+    const key = generateSessionKey('MSI', 'other-sess')
+    insertSyncedRecord(db, makeSynced({ id: 'merged', deviceInstanceId: 'device-b', device: 'MSI', sessionKey: key }))
+    // Old merge: real source_file, line_offset 0, session_id = session_key, default origin.
+    insertRecord(db, makeRecord({ id: 'merged', deviceInstanceId: 'device-b', device: 'MSI', sessionId: key, syncedAt: 2000 }))
+    markRecordsSynced(db, ['merged'], 3000, 'github:user/repo') // the bug also "uploaded" it
+
+    rerun()
+
+    expect(db.prepare('SELECT origin, source_file, cwd FROM records WHERE id = ?').get('merged')).toEqual({
+      origin: 'synced',
+      source_file: 'C:\\Users\\alice\\.claude\\projects\\p\\s.jsonl',
+      cwd: 'C:\\Users\\alice\\proj',
+    })
+    expect(db.prepare('SELECT COUNT(*) AS n FROM sync_record_state WHERE record_id = ?').get('merged')).toEqual({ n: 0 })
+    expect(getUnsyncedRecords(db, 'github:user/repo', 'device-a').map(r => r.id)).not.toContain('merged')
+  })
+
+  it('flags echoes of this device\'s own records that bounced through another device', () => {
+    // The echo carries our own device id but was merged from synced_records.
+    const echoKey = generateSessionKey('G14', generateSessionKey('G14', 'sess-uuid'))
+    insertSyncedRecord(db, makeSynced({ id: 'echo', sessionKey: echoKey }))
+    insertRecord(db, makeRecord({ id: 'echo', sessionId: echoKey }))
+    // The genuine local record.
+    insertRecord(db, makeRecord({ id: 'real', lineOffset: 512 }))
+
+    rerun()
+
+    expect(db.prepare('SELECT origin FROM records WHERE id = ?').get('echo')).toEqual({ origin: 'synced' })
+    expect(db.prepare('SELECT origin FROM records WHERE id = ?').get('real')).toEqual({ origin: 'local' })
+  })
+
+  it('leaves genuine local rows alone even when a synced row shares the id', () => {
+    // Tools that upload record.id verbatim (e.g. hermes) round-trip the same id;
+    // if such a record was echoed back, the local row keeps its real session id.
+    insertSyncedRecord(db, makeSynced({ id: 'same-id', tool: 'hermes', sessionKey: generateSessionKey('G14', 'hermes-sess') }))
+    insertRecord(db, makeRecord({ id: 'same-id', tool: 'hermes', sessionId: 'hermes-sess', sourceFile: '/db.sqlite:session:hermes-sess:t' }))
+
+    rerun()
+
+    expect(db.prepare('SELECT origin FROM records WHERE id = ?').get('same-id')).toEqual({ origin: 'local' })
+    expect(getUnsyncedRecords(db, undefined, 'device-a').map(r => r.id)).toContain('same-id')
+  })
+
+  it('does not touch ordinary local rows', () => {
+    insertRecord(db, makeRecord({ id: 'local-1', lineOffset: 10 }))
+    insertRecord(db, makeRecord({ id: 'local-2', lineOffset: 20, deviceInstanceId: 'unknown' }))
+    rerun()
+    const rows = db.prepare(`SELECT id FROM records WHERE origin = 'local' ORDER BY id`).all()
+    expect(rows).toEqual([{ id: 'local-1' }, { id: 'local-2' }])
+  })
+})

--- a/packages/cli/tests/db/records-provenance.test.ts
+++ b/packages/cli/tests/db/records-provenance.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import type { StatsRecord } from '@aiusage/core'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord, getRecordById, getUnsyncedRecords, markRecordsSynced, repairRecordProvenance } from '../../src/db/records.js'
+
+function rec(overrides: Partial<StatsRecord>): StatsRecord {
+  return {
+    id: 'r',
+    ts: 1000,
+    ingestedAt: 1000,
+    updatedAt: 1000,
+    lineOffset: 10,
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0,
+    costSource: 'pricing',
+    sessionId: 's',
+    sourceFile: 'C:\\Users\\alice\\.claude\\projects\\p\\s.jsonl',
+    device: 'G14',
+    deviceInstanceId: 'device-a',
+    ...overrides,
+  }
+}
+
+describe('records provenance', () => {
+  let db: Database.Database
+  beforeEach(() => { db = new Database(':memory:'); initializeDatabase(db) })
+  afterEach(() => db.close())
+
+  it('defaults origin to local and round-trips it', () => {
+    insertRecord(db, rec({ id: 'l' }))
+    insertRecord(db, rec({ id: 's', origin: 'synced' }))
+    expect(getRecordById(db, 'l')?.origin).toBe('local')
+    expect(getRecordById(db, 's')?.origin).toBe('synced')
+  })
+
+  it('never returns synced rows as unsynced, whatever their source_file', () => {
+    insertRecord(db, rec({ id: 'pulled', origin: 'synced', deviceInstanceId: 'device-b' }))
+    insertRecord(db, rec({ id: 'pulled-placeholder', origin: 'synced', sourceFile: 'synced/device-b', deviceInstanceId: 'device-b' }))
+    insertRecord(db, rec({ id: 'mine' }))
+    expect(getUnsyncedRecords(db).map(r => r.id)).toEqual(['mine'])
+    expect(getUnsyncedRecords(db, 'github:x/y').map(r => r.id)).toEqual(['mine'])
+    expect(getUnsyncedRecords(db, 'github:x/y', 'device-a').map(r => r.id)).toEqual(['mine'])
+  })
+
+  it('excludes rows stamped with another device id when the current device is known', () => {
+    insertRecord(db, rec({ id: 'foreign', deviceInstanceId: 'device-b' })) // origin local but not ours
+    insertRecord(db, rec({ id: 'pre-init', deviceInstanceId: 'unknown' }))
+    insertRecord(db, rec({ id: 'mine' }))
+    expect(getUnsyncedRecords(db, 'github:x/y', 'device-a').map(r => r.id).sort()).toEqual(['mine', 'pre-init'])
+    // Without a device id the provenance flag alone decides (legacy callers).
+    expect(getUnsyncedRecords(db, 'github:x/y').map(r => r.id).sort()).toEqual(['foreign', 'mine', 'pre-init'])
+  })
+
+  it('repairRecordProvenance re-flags foreign-device rows and drops their sync bookkeeping', () => {
+    insertRecord(db, rec({ id: 'foreign', deviceInstanceId: 'device-b' }))
+    insertRecord(db, rec({ id: 'mine' }))
+    insertRecord(db, rec({ id: 'pre-init', deviceInstanceId: 'unknown' }))
+    markRecordsSynced(db, ['foreign', 'mine'], 2000, 'github:x/y')
+
+    expect(repairRecordProvenance(db, 'device-a')).toBe(1)
+    expect(repairRecordProvenance(db, 'device-a')).toBe(0) // idempotent
+
+    expect(getRecordById(db, 'foreign')?.origin).toBe('synced')
+    expect(getRecordById(db, 'mine')?.origin).toBe('local')
+    expect(getRecordById(db, 'pre-init')?.origin).toBe('local')
+    expect(db.prepare('SELECT record_id FROM sync_record_state ORDER BY record_id').all()).toEqual([{ record_id: 'mine' }])
+  })
+
+  it('re-parsing a row keeps it local (INSERT OR REPLACE writes origin explicitly)', () => {
+    insertRecord(db, rec({ id: 'x', origin: 'synced' }))
+    insertRecord(db, rec({ id: 'x', updatedAt: 2000 }))
+    expect(getRecordById(db, 'x')?.origin).toBe('local')
+  })
+})

--- a/packages/cli/tests/db/schema.test.ts
+++ b/packages/cli/tests/db/schema.test.ts
@@ -117,7 +117,7 @@ describe('Database Schema', () => {
   it('records latest schema version', () => {
     initializeDatabase(db)
     const version = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get()
-    expect((version as any).version).toBe(12)
+    expect((version as any).version).toBe(13)
   })
 
   it('queries visualization views successfully', () => {

--- a/packages/cli/tests/sync/cloud-orchestrator-echo.test.ts
+++ b/packages/cli/tests/sync/cloud-orchestrator-echo.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { generateRecordId, generateSessionKey, generateSyncRecordId } from '@aiusage/core'
+import type { SyncRecord } from '@aiusage/core'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord } from '../../src/db/records.js'
+
+// The cloud pull endpoint returns every device's records, including our own.
+// For Claude Code the local id (hash of message id) differs from the wire id
+// (hash of source file + offset), so without a device check our own records
+// would be merged back as new "local" rows and pushed again with colliding ids.
+
+const pulled: SyncRecord[] = []
+
+vi.mock('../../src/sync/cloud.js', () => ({
+  CloudSyncError: class CloudSyncError extends Error {},
+  cloudPull: vi.fn(async () => ({ records: pulled, tombstones: [], hasMore: false, syncGeneration: 1 })),
+  cloudPush: vi.fn(async () => ({ inserted: 0, updated: 0, skipped: 0, syncGeneration: 1 })),
+}))
+
+const ME = 'device-me'
+const OTHER = 'device-other'
+const FILE = 'C:\\Users\\alice\\.claude\\projects\\p\\s.jsonl'
+
+function wire(deviceInstanceId: string, n: number): SyncRecord {
+  return {
+    id: generateSyncRecordId(deviceInstanceId, FILE, 100 * (n + 1)),
+    ts: 1000 + n,
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0.001,
+    costSource: 'pricing',
+    sessionKey: generateSessionKey('dev', 'sess'),
+    device: 'dev',
+    deviceInstanceId,
+    updatedAt: 1000,
+    sourceFile: FILE,
+    cwd: 'C:\\proj',
+  }
+}
+
+describe('CloudSyncOrchestrator provenance', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    initializeDatabase(db)
+    vi.clearAllMocks()
+    pulled.length = 0
+  })
+
+  it('ignores echoes of its own records and never re-pushes pulled records', async () => {
+    const { CloudSyncOrchestrator } = await import('../../src/sync/cloud-orchestrator.js')
+    const { cloudPush } = await import('../../src/sync/cloud.js')
+
+    // Two local Claude Code records (parser-style ids), already pushed earlier.
+    for (const n of [0, 1]) {
+      insertRecord(db, {
+        id: generateRecordId(ME, `msg-${n}`, 0), ts: 1000 + n, ingestedAt: 1000, updatedAt: 1000, syncedAt: 2000,
+        lineOffset: 100 * (n + 1), tool: 'claude-code', model: 'claude-sonnet-4-6', provider: 'anthropic',
+        inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0, thinkingTokens: 0, cost: 0.001,
+        costSource: 'pricing', sessionId: 'sess', sourceFile: FILE, cwd: 'C:\\proj', device: 'dev', deviceInstanceId: ME,
+      })
+    }
+    db.prepare(`INSERT INTO sync_record_state (record_id, target, synced_at) SELECT id, 'cloud', 2000 FROM records`).run()
+
+    // Server returns our own two records (wire ids) plus one from another device.
+    pulled.push(wire(ME, 0), wire(ME, 1), wire(OTHER, 0))
+
+    const result = await new CloudSyncOrchestrator(db, { deviceInstanceId: ME }).sync()
+    expect(result.status).toBe('ok')
+    expect(result.pulledCount).toBe(1)
+    expect(result.mergedCount).toBe(1)
+    expect(result.uploadedCount).toBe(0)
+    expect(cloudPush).not.toHaveBeenCalled()
+
+    expect(db.prepare(`SELECT COUNT(*) n FROM synced_records WHERE device_instance_id = ?`).get(ME)).toEqual({ n: 0 })
+    expect(db.prepare(`SELECT COUNT(*) n FROM records WHERE origin = 'local'`).get()).toEqual({ n: 2 })
+    const other = db.prepare(`SELECT origin, source_file, cwd FROM records WHERE device_instance_id = ?`).all(OTHER)
+    expect(other).toEqual([{ origin: 'synced', source_file: FILE, cwd: 'C:\\proj' }])
+
+    // Second sync: still nothing to push.
+    const again = await new CloudSyncOrchestrator(db, { deviceInstanceId: ME }).sync()
+    expect(again.uploadedCount).toBe(0)
+    expect(cloudPush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/tests/sync/cross-device-provenance.test.ts
+++ b/packages/cli/tests/sync/cross-device-provenance.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { generateRecordId, generateSessionKey, generateSyncRecordId } from '@aiusage/core'
+import type { StatsRecord } from '@aiusage/core'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord, getUnsyncedRecords, getRecordById } from '../../src/db/records.js'
+import { insertSyncedRecord } from '../../src/db/synced-records.js'
+import { SyncOrchestrator } from '../../src/sync/index.js'
+import { generateSummary } from '../../src/commands/summary.js'
+import { FakeSyncBackend } from './helpers/fake-backend.js'
+
+// Regression for the cross-device GitHub sync bug: records pulled from device A
+// kept their real `source_file` (e.g. C:\Users\alice\.claude\...), so device B's
+// `source_file NOT LIKE 'synced/%'` heuristic treated them as local and
+// re-uploaded them under B's namespace with `line_offset = 0` (colliding ids).
+
+const DEVICE_A = '0a1b2c3d-1111-4aaa-8aaa-aaaaaaaaaaaa' // G14
+const DEVICE_B = '0a1b2c3d-2222-4bbb-8bbb-bbbbbbbbbbbb' // MSI
+const TARGET = 'github:example/aiusage-data'
+const SOURCE_FILE_A = 'C:\\Users\\alice\\.claude\\projects\\C--Users-alice\\session.jsonl'
+const CWD_A = 'C:\\Users\\alice\\Documents\\GitHub\\aiusage'
+const SESSION_A = '9f8e7d6c-3333-4ccc-8ccc-cccccccccccc'
+const DAY = Date.UTC(2026, 8, 6, 12, 0, 0)
+
+/** Build a record the way the Claude Code parser does (id from message id, offset 0 in the hash). */
+function claudeRecord(deviceInstanceId: string, device: string, sourceFile: string, cwd: string, sessionId: string, n: number): StatsRecord {
+  const messageId = `msg_${deviceInstanceId.slice(0, 4)}_${n}`
+  return {
+    id: generateRecordId(deviceInstanceId, messageId, 0),
+    ts: DAY + n * 60_000,
+    ingestedAt: DAY + 1_000_000,
+    updatedAt: DAY + 1_000_000,
+    lineOffset: 100 + n * 1234,
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 1000 + n,
+    outputTokens: 500 + n,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 200,
+    thinkingTokens: 0,
+    cost: 0.01 * (n + 1),
+    costSource: 'pricing',
+    sessionId,
+    sourceFile,
+    cwd,
+    device,
+    deviceInstanceId,
+    platform: 'win32',
+  }
+}
+
+function newDb(): Database.Database {
+  const db = new Database(':memory:')
+  initializeDatabase(db)
+  return db
+}
+
+function orchestrator(db: Database.Database, backend: FakeSyncBackend, deviceInstanceId: string) {
+  return new SyncOrchestrator(db, backend, { deviceInstanceId, target: TARGET, consentVerified: true })
+}
+
+function summaryOf(db: Database.Database, deviceInstanceId: string) {
+  const s = generateSummary(db, { currentDeviceInstanceId: deviceInstanceId })
+  return { totalTokens: s.totalTokens, totalCost: Number(s.totalCost.toFixed(9)), recordCount: s.recordCount, byTool: s.byTool }
+}
+
+describe('cross-device provenance (A → B → A)', () => {
+  let backend: FakeSyncBackend
+  let dbA: Database.Database
+  let dbB: Database.Database
+  let recordsA: StatsRecord[]
+
+  beforeEach(() => {
+    backend = new FakeSyncBackend()
+    dbA = newDb()
+    dbB = newDb()
+    // Device A: multiple Claude Code records from ONE source file.
+    recordsA = [0, 1, 2, 3].map(n => claudeRecord(DEVICE_A, 'G14', SOURCE_FILE_A, CWD_A, SESSION_A, n))
+    for (const r of recordsA) insertRecord(dbA, r)
+  })
+
+  it('never re-uploads pulled records and keeps every id distinct', async () => {
+    // 1–2. A uploads.
+    const a1 = await orchestrator(dbA, backend, DEVICE_A).sync()
+    expect(a1.status).toBe('ok')
+    expect(a1.uploadedCount).toBe(4)
+    const uploadedIdsA = backend.linesUnder(DEVICE_A).map(l => l.id)
+    expect(new Set(uploadedIdsA).size).toBe(4)
+    expect(uploadedIdsA.sort()).toEqual(recordsA.map(r => generateSyncRecordId(DEVICE_A, SOURCE_FILE_A, r.lineOffset)).sort())
+
+    // 3–4. B pulls and merges.
+    const b1 = await orchestrator(dbB, backend, DEVICE_B).sync()
+    expect(b1.status).toBe('ok')
+    expect(b1.pulledCount).toBe(4)
+    expect(b1.mergedCount).toBe(4)
+    expect(b1.uploadedCount).toBe(0)
+
+    // Pulled rows are visible locally, flagged as synced, with source_file and cwd intact.
+    const mergedRows = dbB.prepare(`SELECT id, origin, source_file, cwd, device_instance_id, line_offset FROM records`).all() as any[]
+    expect(mergedRows).toHaveLength(4)
+    for (const row of mergedRows) {
+      expect(row.origin).toBe('synced')
+      expect(row.source_file).toBe(SOURCE_FILE_A)
+      expect(row.cwd).toBe(CWD_A)
+      expect(row.device_instance_id).toBe(DEVICE_A)
+      expect(row.line_offset).toBe(0) // merged rows have no byte offset…
+    }
+    expect(new Set(mergedRows.map(r => r.id)).size).toBe(4) // …but their ids are still distinct.
+    const syncedRows = dbB.prepare(`SELECT source_file, cwd FROM synced_records`).all() as any[]
+    expect(syncedRows.every(r => r.source_file === SOURCE_FILE_A && r.cwd === CWD_A)).toBe(true)
+
+    // Device A's records are NOT local on device B.
+    expect(getUnsyncedRecords(dbB, TARGET, DEVICE_B)).toHaveLength(0)
+    expect(getUnsyncedRecords(dbB, TARGET)).toHaveLength(0)
+
+    // 5. B now has its own usage and syncs.
+    const recordB = claudeRecord(DEVICE_B, 'MSI', 'C:\\Users\\msi\\.claude\\projects\\p\\s.jsonl', 'C:\\Users\\msi\\proj', 'b-session', 0)
+    insertRecord(dbB, recordB)
+    const b2 = await orchestrator(dbB, backend, DEVICE_B).sync()
+    expect(b2.status).toBe('ok')
+    expect(b2.uploadedCount).toBe(1)
+
+    // 6. B's namespace contains only B's own record; A's records were not re-uploaded there.
+    const linesB = backend.linesUnder(DEVICE_B)
+    expect(linesB).toHaveLength(1)
+    expect(linesB[0].deviceInstanceId).toBe(DEVICE_B)
+    expect(linesB.some(l => l.deviceInstanceId === DEVICE_A)).toBe(false)
+    expect(backend.linesUnder(DEVICE_A)).toHaveLength(4)
+
+    // A pulls B's record; A's own records never come back as "synced".
+    const a2 = await orchestrator(dbA, backend, DEVICE_A).sync()
+    expect(a2.status).toBe('ok')
+    expect(a2.pulledCount).toBe(1)
+    expect(a2.ignoredCount).toBe(0)
+    expect(dbA.prepare(`SELECT COUNT(*) AS n FROM synced_records WHERE device_instance_id = ?`).get(DEVICE_A)).toEqual({ n: 0 })
+    expect(dbA.prepare(`SELECT COUNT(*) AS n FROM records WHERE origin = 'local'`).get()).toEqual({ n: 4 })
+    expect(dbA.prepare(`SELECT COUNT(*) AS n FROM records WHERE origin = 'synced'`).get()).toEqual({ n: 1 })
+
+    // All ids across the whole system remain distinct.
+    const allRemoteIds = [...backend.linesUnder(DEVICE_A), ...backend.linesUnder(DEVICE_B)].map(l => l.id)
+    expect(new Set(allRemoteIds).size).toBe(5)
+
+    // Repeated A → B → A syncs are idempotent: no further writes, no further pulls.
+    const snapshot = new Map(backend.files)
+    const writesBefore = backend.writes.length
+    for (const [db, dev] of [[dbA, DEVICE_A], [dbB, DEVICE_B], [dbA, DEVICE_A], [dbB, DEVICE_B]] as const) {
+      const r = await orchestrator(db, backend, dev).sync()
+      expect(r.status).toBe('ok')
+      expect(r.uploadedCount).toBe(0)
+      expect(r.pulledCount).toBe(0)
+      expect(r.mergedCount).toBe(0)
+    }
+    expect(backend.writes.length).toBe(writesBefore)
+    expect(new Map(backend.files)).toEqual(snapshot)
+
+    // Summary totals are identical on both machines and count each record exactly once.
+    const sumA = summaryOf(dbA, DEVICE_A)
+    const sumB = summaryOf(dbB, DEVICE_B)
+    expect(sumA).toEqual(sumB)
+    expect(sumA.recordCount).toBe(5)
+    const expectedTokens = [...recordsA, recordB].reduce((n, r) => n + r.inputTokens + r.outputTokens + r.cacheReadTokens + r.cacheWriteTokens + r.thinkingTokens, 0)
+    expect(sumA.totalTokens).toBe(expectedTokens)
+
+    // Per-device views agree as well.
+    expect(generateSummary(dbB, { currentDeviceInstanceId: DEVICE_B, device: DEVICE_A }).recordCount).toBe(4)
+    expect(generateSummary(dbA, { currentDeviceInstanceId: DEVICE_A, device: DEVICE_A }).recordCount).toBe(4)
+    expect(generateSummary(dbA, { currentDeviceInstanceId: DEVICE_A, device: DEVICE_B }).recordCount).toBe(1)
+  })
+
+  it('ignores remote lines that do not belong to the namespace they sit in', async () => {
+    await orchestrator(dbA, backend, DEVICE_A).sync()
+    // Simulate a contaminated namespace left behind by the old bug: A's records
+    // (with colliding ids) under B's directory, plus an echo of B's own record.
+    const echoOfA = {
+      ...JSON.parse(backend.files.get(`${DEVICE_A}/2026/09/06.ndjson`)!.split('\n')[0]),
+      id: generateSyncRecordId(DEVICE_A, SOURCE_FILE_A, 0),
+    }
+    backend.files.set(`${DEVICE_B}/2026/09/06.ndjson`, JSON.stringify(echoOfA) + '\n')
+
+    // A third device pulls: the foreign line is ignored, A's real lines are accepted.
+    const dbC = newDb()
+    const c = await orchestrator(dbC, backend, 'device-c').sync()
+    expect(c.pulledCount).toBe(4)
+    expect(c.ignoredCount).toBe(1)
+    expect(dbC.prepare(`SELECT COUNT(*) AS n FROM synced_records WHERE id = ?`).get(echoOfA.id)).toEqual({ n: 0 })
+
+    // A pulls: the echo of its own record is ignored, so nothing is double counted.
+    const a = await orchestrator(dbA, backend, DEVICE_A).sync()
+    expect(a.ignoredCount).toBe(1)
+    expect(a.pulledCount).toBe(0)
+    expect(summaryOf(dbA, DEVICE_A).recordCount).toBe(4)
+  })
+
+  it('repairs a database contaminated by the old heuristic before uploading', async () => {
+    // Pre-fix state on B: A's records merged into `records` as if local (real
+    // source_file, line_offset 0, session_id = wire session key), plus their
+    // synced_records rows. Insert them as `origin: local` to model the old rows.
+    const wire = recordsA.map(r => ({
+      ...r,
+      id: generateSyncRecordId(DEVICE_A, SOURCE_FILE_A, r.lineOffset),
+      sessionKey: generateSessionKey(r.device, r.sessionId),
+    }))
+    for (const w of wire) {
+      insertSyncedRecord(dbB, {
+        id: w.id, ts: w.ts, tool: w.tool, model: w.model, provider: w.provider,
+        inputTokens: w.inputTokens, outputTokens: w.outputTokens, cacheReadTokens: w.cacheReadTokens,
+        cacheWriteTokens: w.cacheWriteTokens, thinkingTokens: w.thinkingTokens, cost: w.cost, costSource: w.costSource,
+        sessionKey: w.sessionKey, device: w.device, deviceInstanceId: w.deviceInstanceId, platform: w.platform,
+        updatedAt: w.updatedAt, sourceFile: w.sourceFile, cwd: w.cwd,
+      })
+      insertRecord(dbB, { ...w, lineOffset: 0, sessionId: w.sessionKey, origin: 'local' })
+    }
+    expect(dbB.prepare(`SELECT COUNT(*) AS n FROM records WHERE origin = 'local'`).get()).toEqual({ n: 4 })
+
+    const b = await orchestrator(dbB, backend, DEVICE_B).sync()
+    expect(b.status).toBe('ok')
+    expect(b.repairedCount).toBe(4)
+    expect(b.uploadedCount).toBe(0)
+    expect(backend.linesUnder(DEVICE_B)).toHaveLength(0)
+    expect(dbB.prepare(`SELECT COUNT(*) AS n FROM records WHERE origin = 'local'`).get()).toEqual({ n: 0 })
+    expect(getUnsyncedRecords(dbB, TARGET, DEVICE_B)).toHaveLength(0)
+    // Still visible with their project information.
+    expect(getRecordById(dbB, wire[0].id)?.cwd).toBe(CWD_A)
+  })
+
+  it('does not hide local pre-init records (device_instance_id = unknown)', async () => {
+    const legacy = claudeRecord('unknown', 'G14', SOURCE_FILE_A, CWD_A, SESSION_A, 9)
+    insertRecord(dbA, legacy)
+    const a = await orchestrator(dbA, backend, DEVICE_A).sync()
+    expect(a.repairedCount).toBe(0)
+    expect(a.uploadedCount).toBe(5)
+    expect(backend.linesUnder(DEVICE_A)).toHaveLength(5)
+  })
+})

--- a/packages/cli/tests/sync/helpers/fake-backend.ts
+++ b/packages/cli/tests/sync/helpers/fake-backend.ts
@@ -1,0 +1,43 @@
+import type { SyncBackend } from '../../../src/sync/index.js'
+
+/**
+ * In-memory file-based backend shared by several "devices" in a test, mimicking
+ * a GitHub/S3 data directory: `<deviceInstanceId>/YYYY/MM/DD.ndjson`.
+ */
+export class FakeSyncBackend implements SyncBackend {
+  readonly files = new Map<string, string>()
+  readonly writes: Array<{ path: string; content: string }> = []
+  flushCount = 0
+
+  async readFile(path: string): Promise<string | null> {
+    return this.files.get(path) ?? null
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content)
+    this.writes.push({ path, content })
+  }
+
+  async listFiles(): Promise<string[]> {
+    return Array.from(this.files.keys()).sort()
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    this.files.delete(path)
+  }
+
+  async flush(): Promise<boolean> {
+    this.flushCount++
+    return true
+  }
+
+  /** All parsed lines currently stored under a namespace. */
+  linesUnder(deviceInstanceId: string): Array<Record<string, any>> {
+    const out: Array<Record<string, any>> = []
+    for (const [path, content] of this.files) {
+      if (!path.startsWith(`${deviceInstanceId}/`)) continue
+      for (const line of content.split('\n').filter(Boolean)) out.push(JSON.parse(line))
+    }
+    return out
+  }
+}

--- a/packages/cli/tests/sync/mapper-provenance.test.ts
+++ b/packages/cli/tests/sync/mapper-provenance.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { generateSyncRecordId } from '@aiusage/core'
+import type { StatsRecord } from '@aiusage/core'
+import { mapStatsRecordToSyncRecord } from '../../src/sync/mapper.js'
+
+// Multiple Claude Code records from ONE source file must never collapse into a
+// single sync id. Locally parsed rows carry their byte offset; rows merged from
+// synced_records carry offset 0 and must keep their wire id (provenance flag,
+// not the source_file value, decides this).
+
+const SOURCE_FILE = 'C:\\Users\\alice\\.claude\\projects\\C--Users-alice\\session.jsonl'
+
+function record(overrides: Partial<StatsRecord>): StatsRecord {
+  return {
+    id: 'r',
+    ts: 1776738085346,
+    ingestedAt: 1776738085700,
+    updatedAt: 1776738085700,
+    lineOffset: 0,
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 200,
+    thinkingTokens: 0,
+    cost: 0.001,
+    costSource: 'pricing',
+    sessionId: 'abc123',
+    sourceFile: SOURCE_FILE,
+    device: 'G14',
+    deviceInstanceId: 'device-a',
+    ...overrides,
+  }
+}
+
+describe('mapper: sync ids for records sharing one source_file', () => {
+  it('keeps the wire id of merged (origin = synced) rows even though line_offset is 0', () => {
+    const merged = ['id-1', 'id-2', 'id-3'].map(id => record({ id, origin: 'synced', lineOffset: 0 }))
+    const ids = merged.map(r => mapStatsRecordToSyncRecord(r).id)
+    expect(ids).toEqual(['id-1', 'id-2', 'id-3'])
+    expect(new Set(ids).size).toBe(3)
+    // Without provenance every one of them would collide to this single id:
+    const collided = generateSyncRecordId('device-a', SOURCE_FILE, 0)
+    expect(ids).not.toContain(collided)
+  })
+
+  it('does not rely on a synced/ source_file prefix', () => {
+    const merged = record({ id: 'wire-id', origin: 'synced', sourceFile: SOURCE_FILE })
+    expect(mapStatsRecordToSyncRecord(merged).id).toBe('wire-id')
+    const legacy = record({ id: 'wire-id-2', origin: 'synced', sourceFile: 'synced/device-a' })
+    expect(mapStatsRecordToSyncRecord(legacy).id).toBe('wire-id-2')
+  })
+
+  it('derives distinct ids for local Claude Code rows from their byte offsets', () => {
+    const locals = [120, 480, 900].map((lineOffset, i) => record({ id: `local-${i}`, lineOffset }))
+    const ids = locals.map(r => mapStatsRecordToSyncRecord(r).id)
+    expect(new Set(ids).size).toBe(3)
+    expect(ids).toEqual([120, 480, 900].map(o => generateSyncRecordId('device-a', SOURCE_FILE, o)))
+  })
+
+  it('preserves source_file and cwd on the wire', () => {
+    const wire = mapStatsRecordToSyncRecord(record({ id: 'x', origin: 'synced', cwd: 'C:\\proj' }))
+    expect(wire.sourceFile).toBe(SOURCE_FILE)
+    expect(wire.cwd).toBe('C:\\proj')
+  })
+})

--- a/packages/cli/tests/sync/ownership.test.ts
+++ b/packages/cli/tests/sync/ownership.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { classifyPulledRecord, namespaceOwnerFromPath } from '../../src/sync/ownership.js'
+import { isUploadableLocalRecord } from '../../src/db/records.js'
+
+describe('namespace ownership', () => {
+  it('derives the namespace owner from the first path segment', () => {
+    expect(namespaceOwnerFromPath('device-a/2026/09/06.ndjson')).toBe('device-a')
+    expect(namespaceOwnerFromPath('device-a')).toBe('device-a')
+  })
+
+  it('accepts records that belong to the namespace they were read from', () => {
+    expect(classifyPulledRecord({ deviceInstanceId: 'device-a' }, 'device-a', 'device-me')).toBeNull()
+    expect(classifyPulledRecord({ deviceInstanceId: 'unknown' }, 'device-a', 'device-me')).toBeNull()
+    expect(classifyPulledRecord({ deviceInstanceId: '' as string }, 'device-a', 'device-me')).toBeNull()
+  })
+
+  it('rejects echoes of our own records and lines from a foreign device', () => {
+    expect(classifyPulledRecord({ deviceInstanceId: 'device-me' }, 'device-a', 'device-me')).toBe('own-device-echo')
+    expect(classifyPulledRecord({ deviceInstanceId: 'device-b' }, 'device-a', 'device-me')).toBe('foreign-namespace')
+  })
+})
+
+describe('isUploadableLocalRecord', () => {
+  it('allows only local rows stamped with this device (or the pre-init sentinel)', () => {
+    expect(isUploadableLocalRecord({ origin: 'local', deviceInstanceId: 'me' }, 'me')).toBe(true)
+    expect(isUploadableLocalRecord({ origin: undefined, deviceInstanceId: 'me' }, 'me')).toBe(true)
+    expect(isUploadableLocalRecord({ origin: 'local', deviceInstanceId: 'unknown' }, 'me')).toBe(true)
+    expect(isUploadableLocalRecord({ origin: 'synced', deviceInstanceId: 'me' }, 'me')).toBe(false)
+    expect(isUploadableLocalRecord({ origin: 'local', deviceInstanceId: 'other' }, 'me')).toBe(false)
+    expect(isUploadableLocalRecord({ origin: 'synced', deviceInstanceId: 'other' }, 'me')).toBe(false)
+  })
+})

--- a/packages/cli/tests/sync/repair.test.ts
+++ b/packages/cli/tests/sync/repair.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { generateSessionKey, generateSyncRecordId } from '@aiusage/core'
+import type { StatsRecord, SyncRecord } from '@aiusage/core'
+import { initializeDatabase } from '../../src/db/index.js'
+import { insertRecord, markRecordsSynced } from '../../src/db/records.js'
+import { insertSyncedRecord, mergeSyncedRecordsIntoRecords } from '../../src/db/synced-records.js'
+import { SyncOrchestrator } from '../../src/sync/index.js'
+import { repairSyncContamination, planRemoteRepair, SessionKeyChain } from '../../src/sync/repair.js'
+import { generateSummary } from '../../src/commands/summary.js'
+import { FakeSyncBackend } from './helpers/fake-backend.js'
+
+// Models the real contaminated state observed in the field:
+//   G14 (A) uploaded 4 records; MSI (B) pulled, merged, and re-uploaded them under
+//   B's namespace as echoes (colliding id, hashed session key); A then pulled the
+//   echoes back, merged them, and re-uploaded them under A's namespace again.
+
+const A = 'device-a'
+const B = 'device-b'
+const FILE_A = 'C:\\Users\\alice\\.claude\\projects\\p\\s.jsonl'
+const DAY = Date.UTC(2026, 8, 6, 10, 0, 0)
+
+function localRecord(n: number): StatsRecord {
+  return {
+    id: `local-${n}`,
+    ts: DAY + n * 1000,
+    ingestedAt: DAY,
+    updatedAt: DAY,
+    lineOffset: 100 * (n + 1),
+    tool: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    inputTokens: 100 + n,
+    outputTokens: 50,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    thinkingTokens: 0,
+    cost: 0.001,
+    costSource: 'pricing',
+    sessionId: 'sess-a',
+    sourceFile: FILE_A,
+    cwd: 'C:\\proj',
+    device: 'G14',
+    deviceInstanceId: A,
+    platform: 'win32',
+  }
+}
+
+/** Wire line as A legitimately uploaded it. */
+function wireOf(r: StatsRecord): SyncRecord {
+  return {
+    id: generateSyncRecordId(r.deviceInstanceId, r.sourceFile, r.lineOffset),
+    ts: r.ts, tool: r.tool, model: r.model, provider: r.provider,
+    inputTokens: r.inputTokens, outputTokens: r.outputTokens, cacheReadTokens: r.cacheReadTokens,
+    cacheWriteTokens: r.cacheWriteTokens, thinkingTokens: r.thinkingTokens, cost: r.cost, costSource: r.costSource,
+    sessionKey: generateSessionKey(r.device, r.sessionId), device: r.device, deviceInstanceId: r.deviceInstanceId,
+    platform: r.platform, updatedAt: r.updatedAt, sourceFile: r.sourceFile, cwd: r.cwd,
+  }
+}
+
+/** What the old bug produced when another device re-uploaded `parent`. */
+function echoOf(parent: SyncRecord, deviceInstanceId = parent.deviceInstanceId): SyncRecord {
+  return {
+    ...parent,
+    id: generateSyncRecordId(deviceInstanceId, parent.sourceFile ?? '', 0),
+    deviceInstanceId,
+    sessionKey: generateSessionKey(parent.device, parent.sessionKey),
+    updatedAt: parent.updatedAt + 1,
+  }
+}
+
+const ndjson = (records: SyncRecord[]) => records.map(r => JSON.stringify(r)).join('\n') + '\n'
+
+describe('sync repair', () => {
+  let backend: FakeSyncBackend
+  let dbA: Database.Database
+  let locals: StatsRecord[]
+  let wires: SyncRecord[]
+  let echoesUnderB: SyncRecord[]
+  let doubleEchoesUnderA: SyncRecord[]
+  let bOwn: SyncRecord
+
+  beforeEach(() => {
+    backend = new FakeSyncBackend()
+    dbA = new Database(':memory:')
+    initializeDatabase(dbA)
+    locals = [0, 1, 2, 3].map(localRecord)
+    for (const r of locals) insertRecord(dbA, r)
+    markRecordsSynced(dbA, locals.map(r => r.id), DAY + 1, 't') // A already uploaded them
+    wires = locals.map(wireOf)
+
+    // B's genuine record.
+    bOwn = wireOf({ ...localRecord(7), id: 'b-7', deviceInstanceId: B, device: 'MSI', sourceFile: 'C:\\Users\\msi\\s.jsonl', sessionId: 'sess-b' })
+
+    // Echo chain. Note every echo of the same file collapses to ONE id, so B's
+    // namespace holds a single line standing in for all four originals.
+    echoesUnderB = [echoOf(wires[3])]
+    doubleEchoesUnderA = [echoOf(echoesUnderB[0])]
+    // Also an 'unknown'-device echo (pre-init records that bounced).
+    const unknownWire = { ...wires[1], id: generateSyncRecordId('unknown', FILE_A, 200), deviceInstanceId: 'unknown' }
+    const unknownEcho = { ...echoOf(unknownWire, 'unknown') }
+
+    backend.files.set(`${A}/2026/09/06.ndjson`, ndjson([...wires, unknownWire, ...doubleEchoesUnderA]))
+    backend.files.set(`${B}/2026/09/06.ndjson`, ndjson([bOwn, ...echoesUnderB, unknownEcho]))
+
+    // A's local DB as the old code left it: echoes pulled into synced_records
+    // (own-device + 'unknown') and merged into records.
+    for (const e of [...echoesUnderB, unknownEcho, bOwn]) insertSyncedRecord(dbA, e)
+    mergeSyncedRecordsIntoRecords(dbA) // no device filter → old behaviour
+  })
+
+  it('classifies contamination deterministically without changing anything (dry run)', async () => {
+    const before = { files: new Map(backend.files), records: dbA.prepare('SELECT COUNT(*) n FROM records').get(), synced: dbA.prepare('SELECT COUNT(*) n FROM synced_records').get() }
+
+    const report = await repairSyncContamination(dbA, { deviceInstanceId: A, backend, allNamespaces: true })
+
+    expect(report.applied).toBe(false)
+    expect(new Map(backend.files)).toEqual(before.files)
+    expect(dbA.prepare('SELECT COUNT(*) n FROM records').get()).toEqual(before.records)
+    expect(dbA.prepare('SELECT COUNT(*) n FROM synced_records').get()).toEqual(before.synced)
+
+    const nsA = report.remote!.namespaces.find(n => n.owner === A)!
+    const nsB = report.remote!.namespaces.find(n => n.owner === B)!
+    expect(nsA).toMatchObject({ lines: 6, foreignLines: 0, echoLines: 1 })
+    expect(nsB).toMatchObject({ lines: 3, foreignLines: 1, echoLines: 1 })
+    // Own-device echo + 'unknown' chain echo in synced_records; B's own record untouched.
+    expect(report.local.echoSyncedIds.sort()).toEqual([echoesUnderB[0].id, echoOf({ ...wires[1], id: '', deviceInstanceId: 'unknown' }, 'unknown').id].sort())
+    expect(report.local.echoSyncedIds).not.toContain(bOwn.id)
+    expect(report.local.echoMergedIds.sort()).toEqual(report.local.echoSyncedIds.slice().sort())
+    expect(report.local.reflagRecordIds).toEqual([])
+  })
+
+  it('applies the repair: genuine records survive, echoes are removed, totals are exact', async () => {
+    const report = await repairSyncContamination(dbA, { deviceInstanceId: A, backend, allNamespaces: true, apply: true })
+    expect(report.applied).toBe(true)
+    expect(report.remoteResult).toMatchObject({ rewritten: 2, deleted: 0, flushed: true })
+
+    // Remote: A keeps its 4 real lines + the legitimate 'unknown' pre-init line; B keeps only its own.
+    const linesA = backend.linesUnder(A)
+    expect(linesA.map(l => l.id).sort()).toEqual([...wires.map(w => w.id), generateSyncRecordId('unknown', FILE_A, 200)].sort())
+    expect(backend.linesUnder(B).map(l => l.id)).toEqual([bOwn.id])
+
+    // Local: only A's 4 local rows + B's genuine record remain.
+    expect(dbA.prepare(`SELECT COUNT(*) n FROM records WHERE origin = 'local'`).get()).toEqual({ n: 4 })
+    expect(dbA.prepare(`SELECT id FROM synced_records`).all()).toEqual([{ id: bOwn.id }])
+    expect(dbA.prepare(`SELECT COUNT(*) n FROM records WHERE origin = 'synced'`).get()).toEqual({ n: 1 })
+
+    const summary = generateSummary(dbA, { currentDeviceInstanceId: A })
+    expect(summary.recordCount).toBe(5)
+    expect(summary.deviceCount).toBe(2)
+
+    // Idempotent: a second run finds nothing.
+    const again = await repairSyncContamination(dbA, { deviceInstanceId: A, backend, allNamespaces: true })
+    expect(again.local).toMatchObject({ reflagRecordIds: [], echoSyncedIds: [], echoMergedIds: [] })
+    expect(again.remote!.files).toEqual([])
+
+    // And a normal sync afterwards is a no-op that re-creates nothing.
+    const r = await new SyncOrchestrator(dbA, backend, { deviceInstanceId: A, target: 't', consentVerified: true }).sync()
+    expect(r).toMatchObject({ status: 'ok', pulledCount: 0, uploadedCount: 0, mergedCount: 0, ignoredCount: 0 })
+  })
+
+  it('only rewrites this device\'s namespace unless --all-namespaces is given', async () => {
+    const report = await repairSyncContamination(dbA, { deviceInstanceId: A, backend, apply: true })
+    expect(report.remote!.files.map(f => f.owner)).toEqual([A])
+    expect(backend.linesUnder(B)).toHaveLength(3) // B's namespace untouched
+  })
+
+  it('deletes a remote file whose every line was contamination', async () => {
+    backend.files.set(`${B}/2026/09/07.ndjson`, ndjson([echoOf(wires[0])]))
+    const report = await repairSyncContamination(dbA, { deviceInstanceId: A, backend, allNamespaces: true, apply: true })
+    expect(report.remoteResult!.deleted).toBe(1)
+    expect(backend.files.has(`${B}/2026/09/07.ndjson`)).toBe(false)
+  })
+
+  it('never flags a genuine record whose usage happens to match another', async () => {
+    // Two different sessions with identical usage numbers are not echoes of each other.
+    const chain = new SessionKeyChain()
+    const twin = { ...wires[0], sessionKey: generateSessionKey('G14', 'another-session') }
+    chain.add(wires[0].sessionKey)
+    chain.add(twin.sessionKey)
+    expect(chain.isEcho(wires[0])).toBe(false)
+    expect(chain.isEcho(twin)).toBe(false)
+    expect(chain.isEcho(echoOf(wires[0]))).toBe(true)
+    // A genuine record from a different device alias is not an echo either.
+    expect(chain.isEcho({ device: 'MSI', sessionKey: generateSessionKey('MSI', 'sess-a') })).toBe(false)
+  })
+
+  it('treats a line stamped with a concrete foreign device id as contamination even without a parent', async () => {
+    const stray: SyncRecord = { ...bOwn, id: 'stray', deviceInstanceId: 'device-c', sessionKey: generateSessionKey('MSI', 'x') }
+    backend.files.set(`${B}/2026/09/08.ndjson`, ndjson([stray]))
+    const plan = await planRemoteRepair(backend, { deviceInstanceId: B })
+    const file = plan.files.find(f => f.path === `${B}/2026/09/08.ndjson`)!
+    expect(file).toMatchObject({ foreignLines: 1, echoLines: 0, keptLines: [] })
+  })
+})

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,6 +28,15 @@ export const TOOLS = [
 ] as const
 export type Tool = (typeof TOOLS)[number]
 
+/**
+ * Provenance of a row in the local `records` table.
+ * - `local`: produced by a parser on this device. Only these rows may be uploaded, and only
+ *   under this device's own sync namespace.
+ * - `synced`: copied from `synced_records` (pulled from another device) so local queries can
+ *   see it. Never uploaded, never counted as local usage.
+ */
+export type RecordOrigin = 'local' | 'synced'
+
 export interface StatsRecord {
   id: string                           // sha256(sourceFile + lineOffset) 前 16 位 hex
   ts: number                           // Unix 时间戳（毫秒）
@@ -51,6 +60,7 @@ export interface StatsRecord {
   device: string                       // 设备别名
   deviceInstanceId: string             // 当前安装实例生成的稳定设备实例 ID
   platform?: string                    // 'win32' | 'darwin' | 'linux'
+  origin?: RecordOrigin               // 'local' = parsed on this device (uploadable); 'synced' = pulled from another device (never re-uploaded)
 }
 
 export interface ToolCallRecord {


### PR DESCRIPTION
## Summary

Cross-device sync (GitHub/S3, and the cloud backend) re-uploads records that were pulled from another device, placing them under the *pulling* device's namespace with colliding ids and double-counting usage on every machine.

Records pulled from device A are merged into device B's `records` table so local queries can see them. They keep their real `source_file` and `cwd` (needed for cross-device project stats, added in v1.5.x), so the old `source_file NOT LIKE 'synced/%'` heuristic no longer recognises them as remote. Device B then:

1. selects them in `getUnsyncedRecords()` as if they were local,
2. uploads them under `data/<B>/…` (paths are built from the current device id, not the record's),
3. and because merged rows have `line_offset = 0`, gives every record of one source file the same sync id `sha256(A, sourceFile, 0)`.

Each round trip produces an *echo* whose `sessionKey` is the hash of the original's session key. Echoes bounce back to A, get merged there, and are re-uploaded again. In a real two-device setup this produced 866 echo lines in the repo and a phantom third "device" in summaries. The cloud backend has the same issue: its pull returns the device's own records, and for Claude Code the wire id (file + offset) differs from the local id (message id), so own records were merged back as "local" and pushed again.

## Changes

- **Explicit provenance.** `records.origin` (`'local' | 'synced'`, migration v13). Merge stamps `synced`; parsers stamp `local`. Nothing anywhere decides provenance from `source_file` any more (summary, API server, leaderboard upload, parse backfills all use the origin filter).
- **Upload guard.** `getUnsyncedRecords(db, target, deviceInstanceId)` returns only `origin = 'local'` rows stamped with the current device id (or the pre-init `'unknown'` sentinel); `isUploadableLocalRecord` re-checks each record before mapping. Paths are always under the current device's namespace.
- **Pull ownership check.** A line whose `deviceInstanceId` is a concrete id different from the namespace it sits in, or equal to the pulling device's own id, is ignored (`ignoredCount` in the result, shown in the CLI). Such lines can only be pre-fix echoes; their authoritative copy is in the origin device's namespace.
- **Stable ids.** Merged rows keep their wire id, `source_file`, `cwd` and `platform`; the mapper keeps `record.id` for `origin = 'synced'` rows instead of regenerating it from `(device, sourceFile, 0)`.
- **Runtime guard.** Each sync starts with `repairRecordProvenance`, re-flagging any local row that carries another device's id (nothing is deleted).
- **Migration v13** back-fills `origin` deterministically: a row is `synced` if it has the legacy `synced/` placeholder or its `session_id` equals the `session_key` of the `synced_records` row with the same id (only the merge step ever writes that hash into `session_id`). It also drops `sync_record_state` rows for those records. No records are deleted.
- **Opt-in cleanup:** `aiusage sync --repair [--apply] [--all-namespaces]`. Dry run by default; reports foreign-device lines and echoes per namespace plus local echo rows. Echo detection is a hash pre-image argument (`sessionKey === generateSessionKey(device, K)` for a known session key `K`), cross-checked on real data against an independent fingerprint with identical results. Rules and a manual procedure are in `docs/sync-repair.md`.

## Test Plan

- [x] `pnpm test` passes (cli: 61 files / 448 tests, core: 113, web: 26)
- [x] New regression tests (30): full A → B → A scenario through a shared in-memory backend asserting no re-upload, distinct ids, idempotent repeated syncs, identical summaries on both devices, each record counted once, `source_file`/`cwd` preserved; a pre-contaminated database; foreign-namespace and own-echo pull filtering; cloud own-record echo; migration v13 rules including the "genuine row shares an id" case; repair dry-run/apply/idempotence; multiple Claude Code records from one `source_file` with `line_offset = 0` not collapsing.
- [x] The A → B → A test fails on `main` with `expected 4 to be 0` (B uploads A's 4 records) and passes with this change.
- [x] Manual: migration + `--repair` dry run executed against a copy of a real contaminated database and sync repo (2 devices, ~11k lines): 592 merged rows re-flagged, 427 local echoes and 866 remote echo lines identified, 0 genuine local rows affected, per-device totals unchanged.

Notes for review: `tsc --noEmit` reports a few pre-existing errors on `main` (`clean.ts`, `parse-kilo.ts`, `parse-opencode.ts`, `server.ts`) that are untouched here. The site's pull handler comment says self-records are deduplicated by the merge's `LEFT JOIN`; that only holds when local id == wire id, which is why the cloud orchestrator now skips own-device records explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V11M1ge1pDFEvuC5KnJQab
