### PR TITLE
fix: accept 10-byte protobuf varints in Antigravity parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Antigravity parser rejected valid 10-byte varints** — the protobuf varint reader stopped after 8 bytes, so any generation or step metadata row containing a 10-byte varint (for example an `int64` `-1` sentinel in an unrelated field) failed with `invalid protobuf varint` and every usage record in that row was dropped. The reader now accepts the full 10-byte protobuf maximum and still rejects longer sequences.
+
+---
+
 ## [1.5.15] - 2026-09-08
 
 ### Added

--- a/packages/cli/src/commands/parse-antigravity.ts
+++ b/packages/cli/src/commands/parse-antigravity.ts
@@ -57,11 +57,15 @@ interface StepMetadata {
   events: UsageEvent[]
 }
 
+// A protobuf varint carries at most 64 bits, which is 10 base-128 bytes.
+// Negative int64/int32 values (for example -1 sentinels) always use all 10.
+const MAX_VARINT_BYTES = 10
+
 function readVarint(data: Buffer, start: number): { value: number; offset: number } {
   let value = 0
   let shift = 0
   let offset = start
-  while (offset < data.length && shift < 56) {
+  while (offset < data.length && offset - start < MAX_VARINT_BYTES) {
     const byte = data[offset++]
     value += (byte & 0x7f) * (2 ** shift)
     if ((byte & 0x80) === 0) return { value, offset }

--- a/packages/cli/tests/commands/parse-antigravity.test.ts
+++ b/packages/cli/tests/commands/parse-antigravity.test.ts
@@ -337,6 +337,51 @@ describe('parse-antigravity', () => {
     expect(parse().records[0].ts).toBe(generationTs)
   })
 
+  it('accepts 10-byte varints in generation and step metadata', () => {
+    // int64 -1 on the wire: nine 0xff continuation bytes followed by 0x01.
+    const negativeOne = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01])
+    const maxUint64 = Buffer.concat([varint(99 * 8), negativeOne])
+    const createdAt = Date.UTC(2026, 8, 6, 14, 19, 29, 321)
+    db.prepare('INSERT INTO steps (idx, metadata) VALUES (?, ?)').run(3, Buffer.concat([
+      stepMetadata({ ts: createdAt }),
+      maxUint64,
+    ]))
+    db.prepare('INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)').run(0, Buffer.concat([
+      maxUint64,
+      generationMetadata({
+        model: 'gemini-3.8-flash',
+        usage: usage({ input: 42, totalOutput: 10, thinking: 4, responseOutput: 6 }),
+        stepIndices: [3],
+      }),
+    ]), 1)
+
+    const result = parse()
+
+    expect(result.errors).toEqual([])
+    expect(result.nextIndex).toBe(1)
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0]).toMatchObject({
+      ts: createdAt,
+      model: 'gemini-3.8-flash',
+      inputTokens: 42,
+      outputTokens: 6,
+      thinkingTokens: 4,
+    })
+  })
+
+  it('rejects varints longer than 10 bytes', () => {
+    const overlong = Buffer.concat([varint(99 * 8), Buffer.alloc(11, 0xff)])
+    db.prepare('INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)').run(0, Buffer.concat([
+      generationMetadata({ model: 'gemini-3.8-flash', usage: usage({ input: 1, totalOutput: 1 }) }),
+      overlong,
+    ]), 1)
+
+    const result = parse()
+
+    expect(result.records).toEqual([])
+    expect(result.errors).toEqual(['generation metadata 0: invalid protobuf varint'])
+  })
+
   it('leaves an unfinished metadata row for a later parse', () => {
     db.prepare('INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)').run(0, generationMetadata({}), 0)
 


### PR DESCRIPTION
## Summary

The Antigravity parser's protobuf varint reader stopped after 8 bytes (`shift < 56`), but a protobuf varint carries up to 64 bits, which is 10 base-128 bytes. Negative `int64`/`int32` values such as a `-1` sentinel always use all 10. Any `gen_metadata` or `steps` row containing one threw `invalid protobuf varint`, so every usage record in that row was dropped. On a real Antigravity conversation database this rejected 920 generation metadata rows and omitted hundreds of usage records.

## Changes

- `readVarint` now accepts up to the 10-byte protobuf maximum and still rejects longer sequences.
- Regression tests: a 10-byte varint in an unrelated field of both generation and step metadata now parses cleanly and yields the expected record; an 11-byte sequence is still reported as `invalid protobuf varint`.
- `CHANGELOG.md` gains an Unreleased entry.

Values above 2^53 lose precision as JavaScript numbers. That only affects fields the parser does not consume (sentinels in unknown fields), so decoding stays number-based rather than switching to BigInt.

## Test plan

- [x] The new 10-byte varint test fails on the old code with `generation metadata 0: invalid protobuf varint` and `step metadata 3: invalid protobuf varint`, and passes with the fix.
- [x] `pnpm -r test`: core 113, web 31, widget 23, site 32, cli 500 tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB7Vd7f6weWa5NbaUuav5h
